### PR TITLE
add hs mixing scripts

### DIFF
--- a/add_hsdata.cpp
+++ b/add_hsdata.cpp
@@ -1,0 +1,420 @@
+#include "treesV19Template.h"
+#include <csignal>
+
+struct stat info1;
+struct stat info2;
+
+
+#ifdef __MAKECINT__
+#pragma link C++ class std::vector < std::vector<int> >+;
+#pragma link C++ class std::vector < std::vector<float> >+;
+#endif
+
+using namespace std;
+
+
+void prepareOutBranches(TTree * & outTree);
+void clearOutBranches();
+void getHSSyncRange(std::vector<hsData> &hsDataLoaded, std::vector<double> &dt_low, std::vector<double> &dt_high, int ifile, TTree * inTree);
+int getHSSyncEvent(std::vector<hsData> &hsDataLoaded, std::vector<double> dt_low, std::vector<double> dt_high, double event_time_fromTDC);
+TTree * combine_hs_ntuples(TTree * inTree, int fileNumber);
+TTree * splitTree(TTree * tree, int file, int events);  
+void add_hsdata(int run);
+void signalHandler(int signum);
+
+/* NOTE: if you want to compile uncomment these lines
+# ifndef __CINT__  // the following code will be invisible for the interpreter
+int main(int charc, char* charv[])
+{
+	gROOT->ProcessLine(".L add_hsdata.cpp++");
+	add_hsdata();
+}
+# endif
+*/
+
+vector<float> corrs = {
+	0.9433962264150942, 1.5669515669515668, 1.226505256451099, 
+	0.9848484848484849, 1.3709677419354838, 0.8868243243243243, 1.5597147950089127, 0.9211495946941782, 
+	1.6983695652173914, 0.8066614623991674, 0.9523809523809523, 0.5, 1.2515644555694618, 
+	1.838235294117647,  0.8333333333333333, 1.0,  0.5128205128205129,  0.9986973512809377, 
+	1.3333333333333335, 0.4444444444444445, 1.0256410256410255, 0.975609756097561, 
+	2.982810920121335, 1.7105263157894732, 0.6263616557734205, 0.8333333333333333, 0.4, 
+	0.4444444444444445, 2.1052631578947367, 0.8, 0.3076923076923077, 0.4
+};
+
+int maxEvents=-1;
+TString year = "2018"; // must be changed for corresponding hs data
+TString hs_file_dir= "/data/HSdata/" + year;
+
+void add_hsdata(int runNumber){
+	signal(SIGINT, signalHandler); 
+
+	TString runFile = "/data/trees_v19/Run"+to_string(runNumber)+".root";
+	TString outFileName = "/data/trees_v19/HS_Run"+to_string(runNumber)+".root";
+	TString tmpFilesDir = "/data/trees_v19/Run"+to_string(runNumber)+"/";
+
+    // Get input tree from file
+	cout << "Input file: " << runFile << endl;
+	cout << "Output file: " << outFileName << endl;
+	TFile * f = TFile::Open(runFile, "read");
+	if(f == nullptr){return;}
+
+	TTree * inputTree = (TTree*)f->Get("t");
+	SetAddresses_nohs(inputTree);
+
+	int inputTreeEvents = inputTree->GetEntries();
+
+	if(inputTreeEvents == 0) inputTreeEvents =inputTree->GetEntries();
+	if(inputTreeEvents == 0){
+		cerr << "ERROR: No events added" << endl;
+		return;
+	}
+	cout<< "Entries added: " << inputTreeEvents  << endl;
+
+	//how many files in each tree?           //FIXME: load fileNums directly this may be too slow
+	// vector<int> files = {};
+	// for(int iE=0; iE < maxEvents; iE++){
+	// 	inputTree->GetEntry(iE);
+
+	// 	bool duplicate_file = false;
+	// 	for(int iFile = 0; iFile < files.size(); iFile++){
+	// 		if(fileNum == files[iFile]){
+	// 			duplicate_file = true;
+	// 		}
+	// 	}
+	// 	if(!duplicate_file) files.push_back(fileNum);
+	// }
+	// int n_files = files.size();
+
+	int n_files = 0;
+	if(inputTreeEvents % 1000 == 0){ n_files = inputTreeEvents/1000; }
+	else{ n_files = (inputTreeEvents/1000)+1; }
+
+	/* loop over files, split input tree based on file
+	add hs data for each split tree
+	recombine each hs addded tree */
+
+	cout << "Number of files to run over: " << n_files << endl;
+
+	// create temp trees directory
+	gSystem->Exec("mkdir "+tmpFilesDir);
+
+	for(int iFile = 1; iFile < n_files + 1 ; iFile++){
+		// if(iFile > 3){ continue;} // testing 
+
+		cout << "\nWorking on file: " << iFile << endl;
+		TFile * tmp_tree_file = new TFile(tmpFilesDir+"HS_tree"+toTstring(to_string(iFile))+".root", "recreate");
+		
+		TTree * temp_tree = splitTree(inputTree, iFile, inputTreeEvents);
+		maxEvents = temp_tree->GetEntries();
+
+		TTree * temp_tree_hsadded = combine_hs_ntuples(temp_tree, iFile);
+		temp_tree_hsadded->SetName("t");
+
+		tmp_tree_file->cd();
+		temp_tree_hsadded->Write();
+		tmp_tree_file->Close();
+
+		delete tmp_tree_file;
+	}
+
+
+	cout << "\nMerging trees..." << endl;
+	TChain * finalChain = new TChain("t");
+	finalChain->Add(tmpFilesDir+"*.root");
+	SetAddresses(finalChain);
+	finalChain->Merge(outFileName);
+
+	// remove tmp files
+	gSystem->Exec("rm "+tmpFilesDir+"*.root");
+
+	delete finalChain;
+}
+
+
+TTree * combine_hs_ntuples(TTree * inTree, int fileNumber){
+
+	TTree * outTree = inTree->CloneTree(0);
+	prepareOutBranches(outTree);
+	SetAddresses(outTree);
+
+
+	std::vector<hsData> hsDataLoaded;
+	std::vector<double> dt_low;
+	std::vector<double> dt_high;
+	getHSSyncRange(hsDataLoaded,dt_low,dt_high,fileNumber,inTree);
+
+	for(auto c: corrs){
+		v_nPECorr->push_back(c);
+	}
+
+	cout << " Combining tuple event:";
+	for(int i=0; i<maxEvents; i++){
+
+		if(i%(maxEvents/5)==0) cout << i << std::flush;
+		inTree->GetEntry(i);
+
+		int sync_hs_event_index = getHSSyncEvent(hsDataLoaded,dt_low,dt_high,event_time_fromTDC);
+
+		if (sync_hs_event_index>0){
+
+			for(unsigned int j=0; j<hsDataLoaded.at(sync_hs_event_index).getHSData().size(); j++){
+				if(hsDataLoaded.at(sync_hs_event_index).getHSData().at(j)==1){
+					// cout << std::flush << "j: " << j << endl;
+					v_hs->push_back(j);
+				}
+			}
+
+			for(unsigned int j=0; j<hsDataLoaded.at(sync_hs_event_index).getTPData().size(); j++){
+				if(hsDataLoaded.at(sync_hs_event_index).getTPData().at(j)==1){
+					v_tp->push_back(j);
+				}
+			}
+			
+			hs_time = hsDataLoaded.at(sync_hs_event_index).getMicroTime();
+			extrg   = hsDataLoaded.at(sync_hs_event_index).isMQEvent();
+		}
+		else{
+			extrg   =  0;
+			hs_time = -1;
+			v_hs->push_back(-1);
+			v_tp->push_back(-1);
+		}
+
+		if (sync_hs_event_index>0){
+			// Tracking
+			// get fit parameter
+			vector<double> parFit = doFit(v_hs);
+
+			if(parFit.size()>0){
+				//cout << parFit[0] << " " << parFit[1] << endl;
+				//cout << parFit[2] << " " << parFit[3] << endl;
+
+				v_fit_xz->push_back(parFit[0]);
+				v_fit_xz->push_back(parFit[1]);
+				v_fit_yz->push_back(parFit[2]);
+				v_fit_yz->push_back(parFit[3]);
+			}
+			parFit.clear();
+		}
+		outTree->Fill();
+		clearOutBranches();
+		ClearVectors();
+
+		fillNum=0;
+		beam=false;
+		hardNoBeam=false;
+		fillAvgLumi=-1;
+		fillTotalLumi=-1;
+	} // end event for loop
+
+	hsDataLoaded.clear();
+	dt_low.clear();
+	dt_high.clear();
+
+	return outTree;
+}
+
+
+
+void prepareOutBranches(TTree * & outTree){
+
+	TBranch * b_extrg   = outTree->Branch("extrg",&extrg,"extrg/I");
+	TBranch * b_hs_time = outTree->Branch("hs_time",&hs_time,"hs_time/D");
+	TBranch * b_v_hs      = outTree->Branch("hs",&v_hs);
+	TBranch * b_v_tp      = outTree->Branch("tp",&v_tp);
+	TBranch * b_v_fit_xz  = outTree->Branch("fit_xz",&v_fit_xz);
+	TBranch * b_v_fit_yz  = outTree->Branch("fit_yz",&v_fit_yz);
+
+	TBranch * b_v_nPECorr = outTree->Branch("nPECorr", &v_nPECorr);
+
+	outTree->SetBranchAddress("extrg",    &extrg,     &b_extrg);
+	outTree->SetBranchAddress("hs_time",  &hs_time,   &b_hs_time);
+	outTree->SetBranchAddress("hs",     &v_hs,      &b_v_hs);
+	outTree->SetBranchAddress("tp",     &v_tp,      &b_v_tp);
+	outTree->SetBranchAddress("fit_xz", &v_fit_xz,  &b_v_fit_xz);
+	outTree->SetBranchAddress("fit_yz", &v_fit_yz,  &b_v_fit_yz); 
+
+	outTree->SetBranchAddress("nPECorr", &v_nPECorr, &b_v_nPECorr);  
+}
+
+
+void clearOutBranches(){
+	v_hs->clear();
+	v_tp->clear();
+	v_fit_xz->clear();
+	v_fit_yz->clear();
+}
+
+
+
+void getHSSyncRange(std::vector<hsData> &hsDataLoaded, std::vector<double> &dt_low, 
+					std::vector<double> &dt_high, int ifile, TTree* inTree) {
+	// get mq time stamp in the mq first event
+	double event_time_fromTDC_evt0 = -1;
+
+	// int nEntries = inTree->GetEntries();
+
+	for(int i=0; i < maxEvents; i++){
+		inTree->GetEntry(i);
+		if(event==0){
+			event_time_fromTDC_evt0 = event_time_fromTDC;
+		}
+	}
+
+
+	// ------------------------------------------------------------------------------------
+	//  Find HS files to look at
+	// ------------------------------------------------------------------------------------
+	// 1 hour before
+
+	time_t epoch_previous_file = static_cast<int>(event_time_fromTDC_evt0-3600);
+
+	struct tm *date_previous_file = gmtime(&epoch_previous_file);
+	TString hs_previous_file = Form("data_%d%02d%02d%02d.txt", date_previous_file->tm_year+1900, date_previous_file->tm_mon+1, date_previous_file->tm_mday,   date_previous_file->tm_hour);
+
+	// 1 hour after
+	time_t epoch_next_file = static_cast<int>(event_time_fromTDC_evt0+3600);
+	struct tm *date_next_file = gmtime(&epoch_next_file);
+	TString hs_next_file = Form("data_%d%02d%02d%02d.txt", date_next_file->tm_year+1900, date_next_file->tm_mon+1, date_next_file->tm_mday, date_next_file->tm_hour);
+
+	// current
+	time_t epoch = static_cast<int>(event_time_fromTDC_evt0);
+	struct tm *date = gmtime(&epoch);
+	TString hs_current_file = Form("data_%d%02d%02d%02d.txt", date->tm_year+1900, date->tm_mon+1, date->tm_mday, date->tm_hour);
+
+	// std::cout << "HS files in consideration: " << std::endl;
+	// std::cout << hs_previous_file << std::endl;
+	// std::cout << hs_current_file << std::endl;
+	// std::cout << hs_next_file << std::endl;
+
+	// std::cout <<  Form("Time: %d%02d%02d %02d:%02d:%02d", date->tm_year+1900, date->tm_mon+1, date->tm_mday, date->tm_hour, date->tm_min, date->tm_sec) <<    std::endl;
+	// ------------------------------------------------------------------------------------
+	//  Store HS data in memory
+	// ------------------------------------------------------------------------------------
+
+	// 1. if near boundary then look at two adjacent files
+	if(date->tm_min<3 && ifile>1) {
+		loadHSData(hs_file_dir, hs_previous_file, hsDataLoaded, -1);
+	}
+
+	// 2. load events in the main file
+	loadHSData(hs_file_dir, hs_current_file, hsDataLoaded, 0);
+
+	// 3. if the end time is in the next file, add events to memory
+	if(date->tm_min>57) {
+		loadHSData(hs_file_dir, hs_next_file, hsDataLoaded, 1);
+	}
+
+	std::cout << "Number of loaded HS events: " << hsDataLoaded.size() << std::endl;
+
+	// make a histogram of delta(hs time, mq time)
+	TH1D *h1_dt  = new TH1D("h1_dt", "h1_dt", 100000, -10, 10);
+	double mq_current_time=event_time_fromTDC_evt0;
+	double mq_previous_time=event_time_fromTDC_evt0;
+	cout << "Synching HS evt:" << std::flush; 
+
+	for(int i=0; i<maxEvents; i++) {
+		inTree->GetEntry(i);
+		if(i% (maxEvents/5) == 0) cout << i << std::flush; 
+		
+		mq_current_time = event_time_fromTDC;
+
+		// Loop over selected HS events
+		double hs_current_time=0;
+		double hs_previous_time=0;
+		for(unsigned int ihs=0; ihs<hsDataLoaded.size(); ihs++){
+			// only extrg events
+			//if(!hsDataLoaded.at(ihs).isMQEvent()) continue;
+
+			hs_current_time = hsDataLoaded.at(ihs).getMicroTime();
+			// cout << std::fixed;
+
+			double dt_of_dt = (mq_current_time-mq_previous_time) - (hs_current_time-hs_previous_time);
+			dt_of_dt = 0; // not using dt_of_dt in the syncing decision
+			if(TMath::Abs(dt_of_dt)<0.00001) h1_dt->Fill(mq_current_time-hs_current_time);
+
+			hs_previous_time = hs_current_time;
+		}
+
+		mq_previous_time = mq_current_time;
+
+	}
+
+	// extract dT ranges
+	for(int i=1; i<=h1_dt->GetXaxis()->GetNbins(); i++){
+
+		if(h1_dt->GetBinContent(i)>100){
+
+			double range_low = h1_dt->GetBinLowEdge(i-2);
+			double range_high = h1_dt->GetBinLowEdge(i+2);
+			// std::cout << "dT synch range: " << range_low << " - " << range_high << std::endl;
+			dt_low.push_back(range_low);
+			dt_high.push_back(range_high);
+		}
+	}
+
+	delete h1_dt;
+}
+
+
+int getHSSyncEvent(std::vector<hsData> &hsDataLoaded, std::vector<double> dt_low, std::vector<double> dt_high, double event_time_fromTDC) {
+
+	double mq_current_time = event_time_fromTDC;
+
+	// Get the window of HS events to compare
+	//double hs_begin_time = hsDataLoaded.at(0).getMicroTime();
+	//double hs_end_time = hsDataLoaded.at(hsDataLoaded.size()-1).getMicroTime();
+	//double hs_total_time = hs_end_time-hs_begin_time;
+
+	//int sync_window_sec = 30;
+
+	// get the indices for synching window
+	//int first_hs_evt = hsDataLoaded.size() * (mq_current_time-sync_window_sec-hs_begin_time)/hs_total_time;
+	//int last_hs_evt  = hsDataLoaded.size() * (mq_current_time+sync_window_sec-hs_begin_time)/hs_total_time;
+
+	int synched=-1;
+	// Loop over selected HS events
+	double hs_current_time=0;
+	//for(int ihs=first_hs_evt; ihs<=last_hs_evt; ++ihs)
+	for(unsigned int ihs=0; ihs<hsDataLoaded.size(); ++ihs)
+	{
+		hs_current_time = hsDataLoaded.at(ihs).getMicroTime();
+
+		for(unsigned int irange=0; irange<dt_low.size(); irange++)
+		{
+			//cout << dt_low.at(irange) << " " << dt_high.at(irange) << " " << mq_current_time-hs_current_time << endl;
+			if( mq_current_time-hs_current_time>dt_low.at(irange) &&
+				mq_current_time-hs_current_time<dt_high.at(irange)
+				) synched = ihs;
+		}
+		if(synched>0)
+		{
+			break;
+		}
+	}
+
+	return synched;
+}
+
+//create a tree with events from one fileNum
+//useful for loading matching HS data file
+TTree * splitTree(TTree* tree, int file, int events){
+
+	TTree * tsplit = tree->CloneTree(0);
+
+	for(int iE = 0; iE<events ;iE++){
+		tree->GetEntry(iE);
+		if(fileNum == file){
+			tsplit->Fill();
+		}
+	}
+
+	return tsplit;
+}
+
+
+void signalHandler( int signum ) {
+   cout << "Interrupt signal (" << signum << ") received.\n";
+   exit(signum);  
+}

--- a/treesV19Template.h
+++ b/treesV19Template.h
@@ -1,0 +1,779 @@
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <sstream>
+#include <iomanip>
+#include <time.h>
+#include <string>
+#include <cmath>
+#include <utility>
+#include <map>
+#include <stdio.h>
+#include <cstdlib>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "TROOT.h"
+#include "TSystem.h"
+#include "TRandom.h"
+#include "TF1.h"
+#include "TFile.h"
+#include "TVirtualFFT.h"
+#include "TTree.h"
+#include "TChain.h"
+#include "TMath.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TGraphErrors.h"
+#include "TCanvas.h"
+#include "TDirectory.h"
+#include "TBranch.h"
+#include "TString.h"
+#include "TStyle.h"
+#include "TPaveStats.h"
+#include "TLatex.h"
+#include "TSystemDirectory.h"
+#include "TSystemFile.h"
+#include "TGaxis.h"
+#include "TLegend.h"
+#include "TColor.h"
+#include "TComplex.h"
+#include "TObjArray.h"
+#include "TObjString.h"
+#include "TH1D.h"
+#include "TH2D.h"
+#include "TGraphAsymmErrors.h"
+#include "utilities.h"
+
+using namespace std;
+
+// Set addresses of ROOT tree branches
+
+int nRollOvers=0;
+int runNumOrig=0;
+int event = 0;
+int fileNum=0;
+int runNum=0;
+int fileID = 0;
+Long64_t event_time_b0=0;
+Long64_t event_time_b1=0;
+double event_time_fromTDC=0;
+bool present_b0;
+bool present_b1;
+int t_since_fill_start=0;
+int t_since_fill_end=0;
+int t_until_next_fill=0;
+string * event_t_string;
+Long64_t event_trigger_time_tag_b0;
+Long64_t event_trigger_time_tag_b1;
+int fillNum = 0;
+float fillAvgLumi=0;
+float fillTotalLumi=0;
+bool beam;
+bool hardNoBeam;
+float chan_muDist[32];
+int chan_trueNPE[32];
+float scale1fb=0;
+int orig_evt=0;
+bool mcTruth_threeBarLine;
+bool mcTruth_fourSlab;
+
+vector<int> * v_npulses = new vector<int>();
+vector<int> * v_ipulse = new vector<int>();
+vector<int> * v_chan = new vector<int>();
+vector<int> * v_layer = new vector<int>();
+vector<int> * v_row = new vector<int>();
+vector<int> * v_column = new vector<int>();
+vector<int> * v_type = new vector<int>();
+vector<float> * v_height = new vector<float>();
+vector<float> * v_time = new vector<float>();
+vector<float> * v_triggerCandidates = new vector<float>();
+vector<float> * v_triggerCandidatesEnd = new vector<float>();
+vector<int> * v_triggerCandidatesChannel = new vector<int>();
+vector<float> * v_time_module_calibrated = new vector<float>();
+vector<float> * v_delay = new vector<float>();
+vector<float> * v_area = new vector<float>();
+vector<float> * v_nPE = new vector<float>();
+vector<float> * v_duration =  new vector<float>();
+vector<bool> * v_quiet = new vector<bool>();
+vector<float> * v_presample_mean = new vector<float>();
+vector<float> * v_presample_RMS = new vector<float>();
+vector<float> * v_sideband_mean = new vector<float>();
+vector<float> * v_sideband_RMS = new vector<float>();
+vector<Long64_t> * v_groupTDC_b0 = new vector<Long64_t>();
+vector<Long64_t> * v_groupTDC_b1 = new vector<Long64_t>();
+vector<float> * v_bx = new vector<float>();
+vector<float> * v_by = new vector<float>();
+vector<float> * v_bz = new vector<float>();
+vector<float> * v_max = new vector<float>();
+vector<float> * v_min = new vector<float>();
+vector<float> * v_triggerBand_mean = new vector<float>();
+vector<float> * v_triggerBand_max = new vector<float>();
+vector<float> * v_triggerBand_maxTime = new vector<float>();
+vector<float> * v_triggerBand_RMS = new vector<float>();
+vector<float> * v_sideband_mean_calib = new vector<float>();
+vector<float> * v_sideband_RMS_calib = new vector<float>();
+vector<float> * v_maxAfterFilter = new vector<float>();
+vector<float> * v_maxThreeConsec = new vector<float>();
+vector<float> * v_minAfterFilter = new vector<float>();
+vector<float> * v_sideband_mean_perFile = new vector<float>();
+vector<float> * v_triggerThreshold = new vector<float>();
+vector<bool> * v_triggerEnable = new vector<bool>();
+vector<int> * v_triggerMajority = new vector<int>();
+vector<int> * v_triggerLogic = new vector<int>();
+
+// nPE corrections directly from Matthew
+vector<float> * v_nPECorr = new vector<float> ();
+
+
+// hodoscope data
+int extrg;
+double hs_time;
+vector<int> * v_hs = new vector<int>();
+vector<int> * v_tp = new vector<int>();
+vector<double> * v_fit_xz = new vector<double>();
+vector<double> * v_fit_yz = new vector<double>();
+
+// function to set branch addresses for everything above
+void SetAddresses(TChain *& tree) {
+
+	tree->SetBranchAddress("triggerBand_mean", &v_triggerBand_mean);
+	tree->SetBranchAddress("triggerBand_max", &v_triggerBand_max);
+	tree->SetBranchAddress("triggerBand_maxTime", &v_triggerBand_maxTime);
+	tree->SetBranchAddress("triggerBand_RMS", &v_triggerBand_RMS);
+	tree->SetBranchAddress("sideband_mean_calib", &v_sideband_mean_calib);
+	tree->SetBranchAddress("sideband_RMS_calib", &v_sideband_RMS_calib);
+	tree->SetBranchAddress("max", &v_max);
+	tree->SetBranchAddress("min", &v_min);
+	tree->SetBranchAddress("maxAfterFilter", &v_maxAfterFilter);
+	tree->SetBranchAddress("minAfterFilter", &v_minAfterFilter);
+	tree->SetBranchAddress("maxThreeConsec", &v_maxThreeConsec);
+	tree->SetBranchAddress("hardNoBeam", &hardNoBeam);
+	tree->SetBranchAddress("t_until_next_fill", &t_until_next_fill);
+	tree->SetBranchAddress("event_t_string", &event_t_string);
+	tree->SetBranchAddress("event", &event);
+	tree->SetBranchAddress("run", &runNum);
+	tree->SetBranchAddress("file", &fileNum);
+	tree->SetBranchAddress("nRollOvers", &nRollOvers);
+	tree->SetBranchAddress("beam", &beam);
+	tree->SetBranchAddress("fillAvgLumi", &fillAvgLumi);
+	tree->SetBranchAddress("fillTotalLumi", &fillTotalLumi);
+	tree->SetBranchAddress("event_time_b0", &event_time_b0);
+	tree->SetBranchAddress("event_time_b1", &event_time_b1);
+	tree->SetBranchAddress("t_since_fill_start", &t_since_fill_start);
+	tree->SetBranchAddress("t_since_fill_end", &t_since_fill_end);
+	tree->SetBranchAddress("file", &fileNum);
+	tree->SetBranchAddress("fill", &fillNum);
+	tree->SetBranchAddress("event_trigger_time_tag_b0", &event_trigger_time_tag_b0);
+	tree->SetBranchAddress("event_trigger_time_tag_b1", &event_trigger_time_tag_b1);
+	tree->SetBranchAddress("present_b0", &present_b0);
+	tree->SetBranchAddress("present_b1", &present_b1);
+	tree->SetBranchAddress("triggerCandidates", &v_triggerCandidates);
+	tree->SetBranchAddress("triggerCandidatesEnd", &v_triggerCandidatesEnd);
+	tree->SetBranchAddress("triggerCandidatesChannel", &v_triggerCandidatesChannel);
+	tree->SetBranchAddress("chan", &v_chan);
+	tree->SetBranchAddress("layer", &v_layer);
+	tree->SetBranchAddress("row", &v_row);
+	tree->SetBranchAddress("column", &v_column);
+	tree->SetBranchAddress("type", &v_type);
+	tree->SetBranchAddress("height", &v_height);
+	tree->SetBranchAddress("time_module_calibrated", &v_time_module_calibrated);
+	tree->SetBranchAddress("time", &v_time);
+	tree->SetBranchAddress("delay", &v_delay);
+	tree->SetBranchAddress("area", &v_area);
+	tree->SetBranchAddress("nPE", &v_nPE);
+	tree->SetBranchAddress("ipulse", &v_ipulse);
+	tree->SetBranchAddress("npulses", &v_npulses);
+	tree->SetBranchAddress("duration", &v_duration);
+	tree->SetBranchAddress("quiet", &v_quiet);
+	tree->SetBranchAddress("presample_mean", &v_presample_mean);
+	tree->SetBranchAddress("presample_RMS", &v_presample_RMS);
+	tree->SetBranchAddress("sideband_mean", &v_sideband_mean);
+	tree->SetBranchAddress("sideband_RMS", &v_sideband_RMS);
+	tree->SetBranchAddress("groupTDC_b0", &v_groupTDC_b0);
+	tree->SetBranchAddress("groupTDC_b1", &v_groupTDC_b1);
+	tree->SetBranchAddress("event_time_fromTDC", &event_time_fromTDC);
+	tree->SetBranchAddress("bx", &v_bx);
+	tree->SetBranchAddress("by", &v_by);
+	tree->SetBranchAddress("bz", &v_bz);
+	tree->SetBranchAddress("sideband_mean_perFile",&v_sideband_mean_perFile);
+	tree->SetBranchAddress("triggerThreshold",&v_triggerThreshold);
+	tree->SetBranchAddress("triggerEnable",&v_triggerEnable);
+	tree->SetBranchAddress("triggerMajority",&v_triggerMajority);
+	tree->SetBranchAddress("triggerLogic",&v_triggerLogic);
+	tree->SetBranchAddress("chan_muDist",&chan_muDist);
+	tree->SetBranchAddress("chan_trueNPE",&chan_trueNPE);
+	tree->SetBranchAddress("scale1fb",&scale1fb);
+	tree->SetBranchAddress("orig_evt",&orig_evt);
+	tree->SetBranchAddress("mcTruth_threeBarLine", &mcTruth_threeBarLine);
+	tree->SetBranchAddress("mcTruth_fourSlab", &mcTruth_fourSlab);
+
+	// hodoscope data
+	tree->SetBranchAddress("extrg", &extrg);
+	tree->SetBranchAddress("hs_time", &hs_time);
+	tree->SetBranchAddress("hs", &v_hs);
+	tree->SetBranchAddress("tp", &v_tp);
+	tree->SetBranchAddress("fit_xz", &v_fit_xz);
+	tree->SetBranchAddress("fit_yz", &v_fit_yz);
+
+	tree->SetBranchAddress("nPECorr", &v_nPECorr);
+	
+}
+
+
+void SetAddresses(TTree *& tree) {
+
+	tree->SetBranchAddress("event", &event);
+	tree->SetBranchAddress("run", &runNum);
+	tree->SetBranchAddress("file", &fileNum);
+	tree->SetBranchAddress("fill", &fillNum);
+	tree->SetBranchAddress("nRollOvers", &nRollOvers);
+	tree->SetBranchAddress("beam", &beam);
+	tree->SetBranchAddress("hardNoBeam", &hardNoBeam);
+	tree->SetBranchAddress("fillAvgLumi", &fillAvgLumi);
+	tree->SetBranchAddress("fillTotalLumi", &fillTotalLumi);
+	tree->SetBranchAddress("present_b0", &present_b0);
+	tree->SetBranchAddress("present_b1", &present_b1);
+	tree->SetBranchAddress("event_time_b0", &event_time_b0);
+	tree->SetBranchAddress("event_time_b1", &event_time_b1);
+	tree->SetBranchAddress("event_time_fromTDC", &event_time_fromTDC);
+	tree->SetBranchAddress("t_since_fill_start", &t_since_fill_start);
+	tree->SetBranchAddress("t_since_fill_end", &t_since_fill_end);
+	tree->SetBranchAddress("t_until_next_fill", &t_until_next_fill);
+	tree->SetBranchAddress("event_t_string", &event_t_string);
+	tree->SetBranchAddress("event_trigger_time_tag_b0", &event_trigger_time_tag_b0);
+	tree->SetBranchAddress("event_trigger_time_tag_b1", &event_trigger_time_tag_b1);
+	tree->SetBranchAddress("chan", &v_chan);
+	tree->SetBranchAddress("triggerCandidates", &v_triggerCandidates);
+	tree->SetBranchAddress("triggerCandidatesEnd", &v_triggerCandidatesEnd);
+	tree->SetBranchAddress("triggerCandidatesChannel", &v_triggerCandidatesChannel);
+	tree->SetBranchAddress("layer", &v_layer);
+	tree->SetBranchAddress("row", &v_row);
+	tree->SetBranchAddress("column", &v_column);
+	tree->SetBranchAddress("type", &v_type);
+	tree->SetBranchAddress("height", &v_height);
+	tree->SetBranchAddress("time", &v_time);
+	tree->SetBranchAddress("time_module_calibrated", &v_time_module_calibrated);
+	tree->SetBranchAddress("delay", &v_delay);
+	tree->SetBranchAddress("area", &v_area);
+	tree->SetBranchAddress("nPE", &v_nPE);
+	tree->SetBranchAddress("ipulse", &v_ipulse);
+	tree->SetBranchAddress("npulses", &v_npulses);
+	tree->SetBranchAddress("duration", &v_duration);
+	tree->SetBranchAddress("quiet", &v_quiet);
+	tree->SetBranchAddress("presample_mean", &v_presample_mean);
+	tree->SetBranchAddress("presample_RMS", &v_presample_RMS);
+	tree->SetBranchAddress("sideband_mean", &v_sideband_mean);
+	tree->SetBranchAddress("sideband_RMS", &v_sideband_RMS);
+	tree->SetBranchAddress("sideband_mean_perFile",&v_sideband_mean_perFile);
+	tree->SetBranchAddress("triggerBand_mean", &v_triggerBand_mean);
+	tree->SetBranchAddress("triggerBand_max", &v_triggerBand_max);
+	tree->SetBranchAddress("triggerBand_maxTime", &v_triggerBand_maxTime);
+	tree->SetBranchAddress("triggerBand_RMS", &v_triggerBand_RMS);
+	tree->SetBranchAddress("sideband_mean_calib", &v_sideband_mean_calib);
+	tree->SetBranchAddress("sideband_RMS_calib", &v_sideband_RMS_calib);
+	tree->SetBranchAddress("groupTDC_b0", &v_groupTDC_b0);
+	tree->SetBranchAddress("groupTDC_b1", &v_groupTDC_b1);
+	tree->SetBranchAddress("max", &v_max);
+	tree->SetBranchAddress("min", &v_min);
+	tree->SetBranchAddress("maxAfterFilter", &v_maxAfterFilter);
+	tree->SetBranchAddress("maxThreeConsec", &v_maxThreeConsec);
+	tree->SetBranchAddress("minAfterFilter", &v_minAfterFilter);
+	tree->SetBranchAddress("triggerThreshold",&v_triggerThreshold);
+	tree->SetBranchAddress("triggerEnable",&v_triggerEnable);
+	tree->SetBranchAddress("triggerMajority",&v_triggerMajority);
+	tree->SetBranchAddress("triggerLogic",&v_triggerLogic);
+	tree->SetBranchAddress("bx", &v_bx);
+	tree->SetBranchAddress("by", &v_by);
+	tree->SetBranchAddress("bz", &v_bz);
+	tree->SetBranchAddress("chan_muDist",&chan_muDist);
+	tree->SetBranchAddress("chan_trueNPE",&chan_trueNPE);
+	tree->SetBranchAddress("scale1fb",&scale1fb);
+	tree->SetBranchAddress("fileID", &fileID);
+	tree->SetBranchAddress("orig_evt",&orig_evt);
+	tree->SetBranchAddress("mcTruth_threeBarLine", &mcTruth_threeBarLine);
+	tree->SetBranchAddress("mcTruth_fourSlab", &mcTruth_fourSlab);
+
+	// hodoscope data
+	tree->SetBranchAddress("extrg", &extrg);
+	tree->SetBranchAddress("hs_time", &hs_time);
+	tree->SetBranchAddress("hs", &v_hs);
+	tree->SetBranchAddress("tp", &v_tp);
+	tree->SetBranchAddress("fit_xz", &v_fit_xz);
+	tree->SetBranchAddress("fit_yz", &v_fit_yz);
+
+	tree->SetBranchAddress("nPECorr", &v_nPECorr);
+	
+}
+
+
+void SetAddresses_nohs(TTree *& tree) {
+
+	tree->SetBranchAddress("event", &event);
+	tree->SetBranchAddress("run", &runNum);
+	tree->SetBranchAddress("file", &fileNum);
+	tree->SetBranchAddress("fill", &fillNum);
+	tree->SetBranchAddress("nRollOvers", &nRollOvers);
+	tree->SetBranchAddress("beam", &beam);
+	tree->SetBranchAddress("hardNoBeam", &hardNoBeam);
+	tree->SetBranchAddress("fillAvgLumi", &fillAvgLumi);
+	tree->SetBranchAddress("fillTotalLumi", &fillTotalLumi);
+	tree->SetBranchAddress("present_b0", &present_b0);
+	tree->SetBranchAddress("present_b1", &present_b1);
+	tree->SetBranchAddress("event_time_b0", &event_time_b0);
+	tree->SetBranchAddress("event_time_b1", &event_time_b1);
+	tree->SetBranchAddress("event_time_fromTDC", &event_time_fromTDC);
+	tree->SetBranchAddress("t_since_fill_start", &t_since_fill_start);
+	tree->SetBranchAddress("t_since_fill_end", &t_since_fill_end);
+	tree->SetBranchAddress("t_until_next_fill", &t_until_next_fill);
+	tree->SetBranchAddress("event_t_string", &event_t_string);
+	tree->SetBranchAddress("event_trigger_time_tag_b0", &event_trigger_time_tag_b0);
+	tree->SetBranchAddress("event_trigger_time_tag_b1", &event_trigger_time_tag_b1);
+	tree->SetBranchAddress("chan", &v_chan);
+	tree->SetBranchAddress("triggerCandidates", &v_triggerCandidates);
+	tree->SetBranchAddress("triggerCandidatesEnd", &v_triggerCandidatesEnd);
+	tree->SetBranchAddress("triggerCandidatesChannel", &v_triggerCandidatesChannel);
+	tree->SetBranchAddress("layer", &v_layer);
+	tree->SetBranchAddress("row", &v_row);
+	tree->SetBranchAddress("column", &v_column);
+	tree->SetBranchAddress("type", &v_type);
+	tree->SetBranchAddress("height", &v_height);
+	tree->SetBranchAddress("time", &v_time);
+	tree->SetBranchAddress("time_module_calibrated", &v_time_module_calibrated);
+	tree->SetBranchAddress("delay", &v_delay);
+	tree->SetBranchAddress("area", &v_area);
+	tree->SetBranchAddress("nPE", &v_nPE);
+	tree->SetBranchAddress("ipulse", &v_ipulse);
+	tree->SetBranchAddress("npulses", &v_npulses);
+	tree->SetBranchAddress("duration", &v_duration);
+	tree->SetBranchAddress("quiet", &v_quiet);
+	tree->SetBranchAddress("presample_mean", &v_presample_mean);
+	tree->SetBranchAddress("presample_RMS", &v_presample_RMS);
+	tree->SetBranchAddress("sideband_mean", &v_sideband_mean);
+	tree->SetBranchAddress("sideband_RMS", &v_sideband_RMS);
+	tree->SetBranchAddress("sideband_mean_perFile",&v_sideband_mean_perFile);
+	tree->SetBranchAddress("triggerBand_mean", &v_triggerBand_mean);
+	tree->SetBranchAddress("triggerBand_max", &v_triggerBand_max);
+	tree->SetBranchAddress("triggerBand_maxTime", &v_triggerBand_maxTime);
+	tree->SetBranchAddress("triggerBand_RMS", &v_triggerBand_RMS);
+	tree->SetBranchAddress("sideband_mean_calib", &v_sideband_mean_calib);
+	tree->SetBranchAddress("sideband_RMS_calib", &v_sideband_RMS_calib);
+	tree->SetBranchAddress("groupTDC_b0", &v_groupTDC_b0);
+	tree->SetBranchAddress("groupTDC_b1", &v_groupTDC_b1);
+	tree->SetBranchAddress("max", &v_max);
+	tree->SetBranchAddress("min", &v_min);
+	tree->SetBranchAddress("maxAfterFilter", &v_maxAfterFilter);
+	tree->SetBranchAddress("maxThreeConsec", &v_maxThreeConsec);
+	tree->SetBranchAddress("minAfterFilter", &v_minAfterFilter);
+	tree->SetBranchAddress("triggerThreshold",&v_triggerThreshold);
+	tree->SetBranchAddress("triggerEnable",&v_triggerEnable);
+	tree->SetBranchAddress("triggerMajority",&v_triggerMajority);
+	tree->SetBranchAddress("triggerLogic",&v_triggerLogic);
+	tree->SetBranchAddress("bx", &v_bx);
+	tree->SetBranchAddress("by", &v_by);
+	tree->SetBranchAddress("bz", &v_bz);
+	tree->SetBranchAddress("chan_muDist",&chan_muDist);
+	tree->SetBranchAddress("chan_trueNPE",&chan_trueNPE);
+	tree->SetBranchAddress("scale1fb",&scale1fb);
+	tree->SetBranchAddress("fileID", &fileID);
+	tree->SetBranchAddress("orig_evt",&orig_evt);
+	tree->SetBranchAddress("mcTruth_threeBarLine", &mcTruth_threeBarLine);
+	tree->SetBranchAddress("mcTruth_fourSlab", &mcTruth_fourSlab);
+}
+
+
+void ClearVectors() {
+
+	v_max->clear();
+	v_maxAfterFilter->clear();
+	v_maxThreeConsec->clear();
+	v_min->clear();
+	v_minAfterFilter->clear();
+	v_chan->clear();
+	v_triggerCandidates->clear();
+	v_triggerCandidatesEnd->clear();
+	v_triggerCandidatesChannel->clear();
+	v_layer->clear();
+	v_row->clear();
+	v_column->clear();
+	v_type->clear();
+	v_height->clear();
+	v_time->clear();
+	v_time_module_calibrated->clear();
+	v_area->clear();
+	v_nPE->clear();
+	v_ipulse->clear();
+	v_npulses->clear();
+	v_duration->clear();
+	v_delay->clear();
+	v_sideband_mean->clear();
+	v_sideband_RMS->clear();
+	v_triggerBand_mean->clear();
+	v_triggerBand_max->clear();
+	v_triggerBand_maxTime->clear();
+	v_triggerBand_RMS->clear();
+	v_sideband_mean_calib->clear();
+	v_sideband_RMS_calib->clear();
+	v_quiet->clear();
+	v_presample_mean->clear();
+	v_presample_RMS->clear();
+	v_groupTDC_b0->clear();
+	v_groupTDC_b1->clear();
+	v_bx->clear();
+	v_by->clear();
+	v_bz->clear();
+	v_sideband_mean_perFile->clear();
+	v_triggerThreshold->clear();
+	v_triggerEnable->clear();
+	v_triggerMajority->clear();
+	v_triggerLogic->clear();
+
+	// hodoscope
+	v_hs->clear();
+	v_tp->clear();
+	v_fit_xz->clear();
+	v_fit_yz->clear();
+}
+
+
+////////////////////////////////////////////////////
+////////////////////////////////////////////////////
+////////////////////////////////////////////////////
+////////////////////////////////////////////////////
+////////////////////////////////////////////////////
+// USEFUL FUNCTIONS:
+
+int LAYERS=3;
+int HEIGHT=3;
+int WIDTH=2;
+int LEFT=0;
+int RIGHT=1;
+int BOTTOM=0;
+int MIDDLE=1;
+int TOP=2;
+int NUM_CHAN = 32;
+enum typeList {kBar = 0, kSlab = 1, kSheet = 2};
+
+void SetAddressesEventComp(TChain *& tree){
+	tree->SetBranchAddress("run", &runNum);
+	tree->SetBranchAddress("event", &event);
+	tree->SetBranchAddress("file", &fileNum);
+}
+
+void SetAddressesEventComp(TTree *& tree){
+	tree->SetBranchAddress("run", &runNum);
+	tree->SetBranchAddress("event", &event);
+	tree->SetBranchAddress("file", &fileNum);
+}
+
+double divison(double a, double b){
+	if(b == 0){
+		throw "Error: divison by zero occured";
+		printf(" at line number %d \n",__LINE__);
+	}
+	return (a/b);
+}
+
+string tostr(int x){
+	stringstream str;
+	str << x;
+	return str.str();
+}
+
+string tostr(double x){
+	stringstream str;
+	str << x;
+	return str.str();
+}
+
+int toint(string text){
+	int number;
+	std::istringstream iss (text);
+	iss >> number;
+	return number;
+}
+
+
+//layer map
+
+/*    L  T  R
+* 2:  31 14 26
+* 1:  11 30 19
+* 0:  27 10 29f
+*/
+
+//first index is layer=0,1,2
+//second index is column: L=0,R=1
+//third index is height in column: bottom=0, top=2
+
+
+vector<int> bars = {};
+void fillBars(){
+	for (int i=0; i<LAYERS; i++){
+		for (int j=0; j<WIDTH; j++){
+			for (int k=0; k<HEIGHT; k++){
+				bars.push_back(channelMap[i][j][k]);
+			}
+		}
+	}
+}
+
+//first index is layer=0,1,2
+//second index is L=0,T=1,R=2
+int sheetMap[3][3] = {
+	{ 27, 10, 29 },
+	{ 11, 30, 19 },
+	{ 31, 14, 26 }
+};
+
+//first index is layer=0,1,2
+//second index is F=0, B=1       "Front" is defined to be toward the IP
+int slabMap[3][2] = {
+	{ 18, 20 },
+	{ 20, 28 },
+	{ 28, 21 }
+};
+
+
+vector<double> cosmicCuts(32, -1.0);
+void setCosmicCuts(){
+ cosmicCuts[2] = 4900;
+ cosmicCuts[22] = 5100;
+ cosmicCuts[4] = 5000;
+ cosmicCuts[3] = 4853;
+ cosmicCuts[23] = 2700;
+ cosmicCuts[5] = 4139;
+ cosmicCuts[6] = 4700;
+ cosmicCuts[16] = 5200;
+ cosmicCuts[12] = 5000;
+ cosmicCuts[7] = 4750;
+ cosmicCuts[17] = 2650;                  //changed it from 26500 to 2650, assuming typo
+ cosmicCuts[13] = 4000;
+ cosmicCuts[0] = 4900;
+ cosmicCuts[24] = 5010;
+ cosmicCuts[8] = 0;
+ cosmicCuts[1] = 4850;
+ cosmicCuts[25] = 2700;
+ cosmicCuts[9] = 4100;
+
+ cosmicCuts[10] = 2000;
+ cosmicCuts[30] = 3000;
+ cosmicCuts[14] = 1000;
+}
+
+string rowName(int row){
+	if (row==0) return "Bottom";
+	else if (row==1) return "Middle";
+	else if (row==2) return "Top";
+	else return "Error";
+}
+
+string columnName(int column){
+	if (column==0) return "Left";
+	else if (column==1) return "Right";
+	else return "Error";
+}
+
+string sheetName(int num){
+	if (num==0) return "Left";
+	else if (num==1) return "Top";
+	else if (num==2) return "Right";
+	else return "Error";
+}
+
+string printVector(vector<int> myVector){
+	string myString = "";
+	for (unsigned int z=0; z<myVector.size(); z++){
+		myString += tostr(myVector[z]);
+		myString += ",";
+	}
+	return myString;
+}
+
+string printVector(vector<double> myVector){
+	string myString = "";
+	for (unsigned int z=0; z<myVector.size(); z++){
+		myString += tostr(myVector[z]);
+		myString += ",";
+	}
+	return myString;
+}
+
+double maxElement(vector<double> thing){
+	double max = -1e99;
+	if(thing.size() > 0) max = thing[0];
+	for(unsigned int i=0; i<thing.size(); ++i){
+		if(thing[i]>max) max = thing[i];
+	}
+	return max;
+}
+
+int maxElement(vector<int> thing){
+	int max = -2147483648;
+	if(thing.size() > 0) max = thing[0];
+	for(unsigned int i=0; i<thing.size(); ++i){
+		if(thing[i]>max) max = thing[i];
+	}
+	return max;
+}
+
+double minElement(vector<double> thing){
+	double min = 1e99;
+	if(thing.size() > 0) min = thing[0];
+	for(unsigned int i=0; i<thing.size(); ++i){
+		if(thing[i]<min) min = thing[i];
+	}
+	return min;
+}
+
+int minElement(vector<int> thing){
+	double min = 1e99;
+	if(thing.size() > 0) min = thing[0];
+	for(unsigned int i=0; i<thing.size(); ++i){
+		if(thing[i]<min) min = thing[i];
+	}
+	return min;
+}
+
+// sorts vector with thing[0] being smallest element
+vector<int> sort_vector(vector<int> thing){
+	vector<int> temp_vector = {};
+	vector<int> sorted_vector = {};
+	int min = minElement(thing);
+	int temp_min = min;
+	temp_vector = thing;
+
+	for(unsigned int j=0; j<thing.size(); ++j){
+		temp_min = minElement(temp_vector);
+		sorted_vector.push_back(temp_min);
+		for(unsigned int i=0; i<temp_vector.size(); ++i){
+			if(temp_vector[i] == temp_min){
+				temp_vector.erase(temp_vector.begin()+i);
+				break;
+			}
+		}
+	}
+	return sorted_vector;
+}
+
+vector<double> sort_vector(vector<double> thing){
+	vector<double> temp_vector = {};
+	vector<double> sorted_vector = {};
+	double min = minElement(thing);
+	double temp_min = min;
+	temp_vector = thing;
+
+	for(unsigned int j=0; j<thing.size(); ++j){
+		temp_min = minElement(temp_vector);
+		sorted_vector.push_back(temp_min);
+		for(unsigned int i=0; i<temp_vector.size(); ++i){
+			if(temp_vector[i] == temp_min){
+				temp_vector.erase(temp_vector.begin() +i);
+				break;
+			}
+		}
+	}
+	return sorted_vector;
+}
+
+
+TString toTstring(string thing){
+		TString thingT = thing;
+		return thingT;
+}
+
+
+double poissRateError(double a, double b, double epsilon = 0.000000000001){
+	double error = 0;
+	double diff = b - 0;
+	if((diff > epsilon) && (-diff < -1*epsilon)) {
+		error = sqrt( ((a)/(pow(b,2)) ) + ( (pow(a,2)) / (pow(b,3))));
+	}
+	else{
+		error = 0;
+	}
+	return error;
+}
+
+
+int getLayer(int chan){
+	int layer = -2;
+	// slabs
+	if(chan == 18) layer = 0;
+	if(chan == 20) layer = 0;
+	if(chan == 28) layer = 0;
+	if(chan == 21) layer = 0;
+
+	// layer 1 bars
+	if(chan == 0) layer = 1;
+	if(chan == 1) layer = 1;
+	if(chan == 24) layer = 1;
+	if(chan == 25) layer = 1;
+	if(chan == 8) layer = 1;
+	if(chan == 9) layer = 1;
+	// layer 1 sheets
+	if(chan == 29) layer = 1;
+	if(chan == 10) layer = 1;
+	if(chan == 27) layer = 1;
+
+	// layer 2 bars
+	if(chan == 6) layer = 2;
+	if(chan == 7) layer = 2;
+	if(chan == 16) layer = 2;
+	if(chan == 17) layer = 2;
+	if(chan == 12) layer = 2;
+	if(chan == 13) layer = 2;
+	// layer 2 sheets
+	if(chan == 19) layer = 2;
+	if(chan == 11) layer = 2;
+	if(chan == 30) layer = 2;
+
+	// layer 3 bars
+	if(chan == 2) layer = 3;
+	if(chan == 3) layer = 3;
+	if(chan == 22) layer = 3;
+	if(chan == 23) layer = 3;
+	if(chan == 4) layer = 3;
+	if(chan == 5) layer = 3;
+	// layer 3 sheets
+	if(chan == 14) layer = 3;
+	if(chan == 26) layer = 3;
+	if(chan == 31) layer = 3;
+
+	if(layer == -2){
+		cout << "Not a valid channel" << endl;
+	}
+
+	return layer;
+}
+
+
+// NB: displayProgress adds ~20% of overhead
+void displayProgress(int i, int entries){
+	cout << std::fixed << std::setprecision(1) << "\r\033[1;35m[" << (i/static_cast<double>(entries-1/100.0))*100 << "%]\033[0m";
+}
+
+// cout debugging
+inline void debug(bool flag, int line){if(flag) cout<<"line "<<line<<" "<<endl;}
+inline void debugVar(bool flag, int line, int var){if(flag) cout<<line<<" "<<var<<endl;}
+inline void debugVar(bool flag, int line, double var){if(flag) cout<<line<<" "<<var<<endl;}
+inline void debugVar(bool flag, int line, string var){if(flag) cout<<line<<" "<<var<<endl;}
+inline void debugVar(bool flag, int line, float var){if(flag) cout<<line<<" "<<var<<endl;}
+inline void debugVar(bool flag, int line, TString var){if(flag) cout<<line<<" "<<var<<endl;}
+inline void debugVar(bool flag, int line, bool var){if(flag) cout<<line<<" "<<var<<endl;}
+
+Long64_t GetTreeIndex(TChain *tree, int runVar, int fileVar, int eventVar, int entries){
+	auto nentries = entries;
+	TString draw_selection = TString::Format("run==%d && file==%d && event==%d",runVar,fileVar, eventVar);
+	TString draw_command = TString::Format("Entry$ >> hist(%d,0,%d)",nentries,nentries);
+	tree->Draw(draw_command,draw_selection,"goff");
+	TH1I *hist = (TH1I*)gDirectory->Get("hist");
+	Long64_t iEntry = hist->GetBinLowEdge(hist->FindFirstBinAbove(0));
+	delete hist;
+	return iEntry;
+}
+
+inline bool file_exists(const std::string& name) {
+	struct stat buffer;   
+	return (stat (name.c_str(), &buffer) == 0); 
+}

--- a/utilities.h
+++ b/utilities.h
@@ -1,0 +1,1256 @@
+//first index is layer=0,1,2
+//second index is column: L=0,R=1
+//third index is height in column: bottom=0, top=2
+int channelMap[3][2][3] = {
+  { {8, 24,0}, {9, 25, 1} },
+  { {12, 16, 6}, {13, 17, 7} },
+  { {4, 22, 2}, {5, 23, 3} }
+};
+
+// define the parametric line equation
+void line(double t, vector<double> parFit, double &x, double &y, double &z)
+{
+  double p[4];
+  // xz
+  p[0] =  -1.*parFit.at(1)/parFit.at(0);
+  p[1] =  1./parFit.at(0);
+  // yz
+  p[2] =  -1.*parFit.at(5)/parFit.at(4);
+  p[3] =  1./parFit.at(4);
+
+  x = p[0] + p[1]*t;
+  y = p[2] + p[3]*t;
+  z = t;
+}
+
+void line(double t, const double *p, double &x, double &y, double &z) {
+    // a parametric line is define from 6 parameters but 4 are independent
+    // x0,y0,z0,z1,y1,z1 which are the coordinates of two points on the line
+    // can choose z0 = 0 if line not parallel to x-y plane and z1 = 1;
+    x = p[0] + p[1]*t;
+    y = p[2] + p[3]*t;
+    z = t;
+ }
+
+std::vector<int> convertRawToPhysCh(unsigned int raw_ch, bool isHS)
+{
+  int phys_ch[3] ={0,0,0}; // x, y, z
+  if(isHS)
+  {
+     // bottom vertical bars
+     if(raw_ch==0)        {phys_ch[0]= -4;  phys_ch[1]=  0;  phys_ch[2]=  2;}
+     else if(raw_ch==1)   {phys_ch[0]= -3;  phys_ch[1]=  0;  phys_ch[2]=  2;}
+     else if(raw_ch==2)   {phys_ch[0]= -2;  phys_ch[1]=  0;  phys_ch[2]=  2;}
+     else if(raw_ch==3)   {phys_ch[0]= -1;  phys_ch[1]=  0;  phys_ch[2]=  2;}
+     else if(raw_ch==4)   {phys_ch[0]= -4;  phys_ch[1]=  0;  phys_ch[2]=  1;}
+     else if(raw_ch==5)   {phys_ch[0]= -3;  phys_ch[1]=  0;  phys_ch[2]=  1;}
+     else if(raw_ch==6)   {phys_ch[0]= -2;  phys_ch[1]=  0;  phys_ch[2]=  1;}
+     else if(raw_ch==7)   {phys_ch[0]= -1;  phys_ch[1]=  0;  phys_ch[2]=  1;}
+     else if(raw_ch==8)   {phys_ch[0]=  1;  phys_ch[1]=  0;  phys_ch[2]=  2;}
+     else if(raw_ch==9)   {phys_ch[0]=  2;  phys_ch[1]=  0;  phys_ch[2]=  2;}
+     else if(raw_ch==10)  {phys_ch[0]=  3;  phys_ch[1]=  0;  phys_ch[2]=  2;}
+     else if(raw_ch==11)  {phys_ch[0]=  4;  phys_ch[1]=  0;  phys_ch[2]=  2;}
+     else if(raw_ch==12)  {phys_ch[0]=  1;  phys_ch[1]=  0;  phys_ch[2]=  1;}
+     else if(raw_ch==13)  {phys_ch[0]=  2;  phys_ch[1]=  0;  phys_ch[2]=  1;}
+     else if(raw_ch==14)  {phys_ch[0]=  3;  phys_ch[1]=  0;  phys_ch[2]=  1;}
+     else if(raw_ch==15)  {phys_ch[0]=  4;  phys_ch[1]=  0;  phys_ch[2]=  1;}
+     // bottom horizontal bars
+     else if(raw_ch==16)  {phys_ch[0]=  0;  phys_ch[1]=  8;  phys_ch[2]=  1;}
+     else if(raw_ch==17)  {phys_ch[0]=  0;  phys_ch[1]=  7;  phys_ch[2]=  1;}
+     else if(raw_ch==18)  {phys_ch[0]=  0;  phys_ch[1]=  6;  phys_ch[2]=  1;}
+     else if(raw_ch==19)  {phys_ch[0]=  0;  phys_ch[1]=  5;  phys_ch[2]=  1;}
+     else if(raw_ch==20)  {phys_ch[0]=  0;  phys_ch[1]=  8;  phys_ch[2]=  2;}
+     else if(raw_ch==21)  {phys_ch[0]=  0;  phys_ch[1]=  7;  phys_ch[2]=  2;}
+     else if(raw_ch==22)  {phys_ch[0]=  0;  phys_ch[1]=  6;  phys_ch[2]=  2;}
+     else if(raw_ch==23)  {phys_ch[0]=  0;  phys_ch[1]=  5;  phys_ch[2]=  2;}
+     else if(raw_ch==24)  {phys_ch[0]=  0;  phys_ch[1]=  4;  phys_ch[2]=  1;}
+     else if(raw_ch==25)  {phys_ch[0]=  0;  phys_ch[1]=  3;  phys_ch[2]=  1;}
+     else if(raw_ch==26)  {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]=  1;}
+     else if(raw_ch==27)  {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]=  1;}
+     else if(raw_ch==28)  {phys_ch[0]=  0;  phys_ch[1]=  4;  phys_ch[2]=  2;}
+     else if(raw_ch==29)  {phys_ch[0]=  0;  phys_ch[1]=  3;  phys_ch[2]=  2;}
+     else if(raw_ch==30)  {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]=  2;}
+     else if(raw_ch==31)  {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]=  2;}
+     // top horizontal bars
+     else if(raw_ch==32)  {phys_ch[0]=  0;  phys_ch[1]=  4;  phys_ch[2]= -2;}
+     else if(raw_ch==33)  {phys_ch[0]=  0;  phys_ch[1]=  3;  phys_ch[2]= -2;}
+     else if(raw_ch==34)  {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]= -2;}
+     else if(raw_ch==35)  {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]= -2;}
+     else if(raw_ch==36)  {phys_ch[0]=  0;  phys_ch[1]=  4;  phys_ch[2]= -1;}
+     else if(raw_ch==37)  {phys_ch[0]=  0;  phys_ch[1]=  3;  phys_ch[2]= -1;}
+     else if(raw_ch==38)  {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]= -1;}
+     else if(raw_ch==39)  {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]= -1;}
+     else if(raw_ch==40)  {phys_ch[0]=  0;  phys_ch[1]=  8;  phys_ch[2]= -2;}
+     else if(raw_ch==41)  {phys_ch[0]=  0;  phys_ch[1]=  7;  phys_ch[2]= -2;}
+     else if(raw_ch==42)  {phys_ch[0]=  0;  phys_ch[1]=  6;  phys_ch[2]= -2;}
+     else if(raw_ch==43)  {phys_ch[0]=  0;  phys_ch[1]=  5;  phys_ch[2]= -2;}
+     else if(raw_ch==44)  {phys_ch[0]=  0;  phys_ch[1]=  8;  phys_ch[2]= -1;}
+     else if(raw_ch==45)  {phys_ch[0]=  0;  phys_ch[1]=  7;  phys_ch[2]= -1;}
+     else if(raw_ch==46)  {phys_ch[0]=  0;  phys_ch[1]=  6;  phys_ch[2]= -1;}
+     else if(raw_ch==47)  {phys_ch[0]=  0;  phys_ch[1]=  5;  phys_ch[2]= -1;}
+     // bottom vertical bars
+     else if(raw_ch==48)  {phys_ch[0]=  4;  phys_ch[1]=  0;  phys_ch[2]= -2;}
+     else if(raw_ch==49)  {phys_ch[0]=  3;  phys_ch[1]=  0;  phys_ch[2]= -2;}
+     else if(raw_ch==50)  {phys_ch[0]=  2;  phys_ch[1]=  0;  phys_ch[2]= -2;}
+     else if(raw_ch==51)  {phys_ch[0]=  1;  phys_ch[1]=  0;  phys_ch[2]= -2;}
+     else if(raw_ch==52)  {phys_ch[0]=  4;  phys_ch[1]=  0;  phys_ch[2]= -1;}
+     else if(raw_ch==53)  {phys_ch[0]=  3;  phys_ch[1]=  0;  phys_ch[2]= -1;}
+     else if(raw_ch==54)  {phys_ch[0]=  2;  phys_ch[1]=  0;  phys_ch[2]= -1;}
+     else if(raw_ch==55)  {phys_ch[0]=  1;  phys_ch[1]=  0;  phys_ch[2]= -1;}
+     else if(raw_ch==56)  {phys_ch[0]= -1;  phys_ch[1]=  0;  phys_ch[2]= -2;}
+     else if(raw_ch==57)  {phys_ch[0]= -2;  phys_ch[1]=  0;  phys_ch[2]= -2;}
+     else if(raw_ch==58)  {phys_ch[0]= -3;  phys_ch[1]=  0;  phys_ch[2]= -2;}
+     else if(raw_ch==59)  {phys_ch[0]= -4;  phys_ch[1]=  0;  phys_ch[2]= -2;}
+     else if(raw_ch==60)  {phys_ch[0]= -1;  phys_ch[1]=  0;  phys_ch[2]= -1;}
+     else if(raw_ch==61)  {phys_ch[0]= -2;  phys_ch[1]=  0;  phys_ch[2]= -1;}
+     else if(raw_ch==62)  {phys_ch[0]= -3;  phys_ch[1]=  0;  phys_ch[2]= -1;}
+     else if(raw_ch==63)  {phys_ch[0]= -4;  phys_ch[1]=  0;  phys_ch[2]= -1;}
+     else
+     {
+       cout << "HS raw_ch = " << raw_ch << " is not correct. Enter a correct raw_ch." << endl;
+     }
+  }
+  else
+  {
+     if(raw_ch==0)        {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]=  4;}
+     else if(raw_ch==1)   {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]=  3;}
+     else if(raw_ch==2)   {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]=  2;}
+     else if(raw_ch==3)   {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]=  1;}
+     else if(raw_ch==4)   {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]=  4;}
+     else if(raw_ch==5)   {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]=  3;}
+     else if(raw_ch==6)   {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]=  2;}
+     else if(raw_ch==7)   {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]=  1;}
+     else if(raw_ch==8)   {phys_ch[0]=  0;  phys_ch[1]= -2;  phys_ch[2]=  1;}
+     else if(raw_ch==9)   {phys_ch[0]=  0;  phys_ch[1]= -2;  phys_ch[2]=  2;}
+     else if(raw_ch==10)  {phys_ch[0]=  0;  phys_ch[1]= -2;  phys_ch[2]=  3;}
+     else if(raw_ch==11)  {phys_ch[0]=  0;  phys_ch[1]= -2;  phys_ch[2]=  4;}
+     else if(raw_ch==12)  {phys_ch[0]=  0;  phys_ch[1]= -1;  phys_ch[2]=  1;}
+     else if(raw_ch==13)  {phys_ch[0]=  0;  phys_ch[1]= -1;  phys_ch[2]=  2;}
+     else if(raw_ch==14)  {phys_ch[0]=  0;  phys_ch[1]= -1;  phys_ch[2]=  3;}
+     else if(raw_ch==15)  {phys_ch[0]=  0;  phys_ch[1]= -1;  phys_ch[2]=  4;}
+     else if(raw_ch==16)  {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]=  1;}
+     else if(raw_ch==17)  {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]=  2;}
+     else if(raw_ch==18)  {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]=  3;}
+     else if(raw_ch==19)  {phys_ch[0]=  0;  phys_ch[1]=  1;  phys_ch[2]=  4;}
+     else if(raw_ch==20)  {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]=  1;}
+     else if(raw_ch==21)  {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]=  2;}
+     else if(raw_ch==22)  {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]=  3;}
+     else if(raw_ch==23)  {phys_ch[0]=  0;  phys_ch[1]=  2;  phys_ch[2]=  4;}
+     else
+     {
+       cout << "TP raw_ch = " << raw_ch << " is not correct. Enter a correct raw_ch." << endl;
+     }
+  }
+
+  std::vector<int> phys_ch_vec;
+  phys_ch_vec.push_back(phys_ch[0]);
+  phys_ch_vec.push_back(phys_ch[1]);
+  phys_ch_vec.push_back(phys_ch[2]);
+  return phys_ch_vec;
+}
+
+std::vector<float> convertPhysChToCoord(std::vector<int> phys_ch, bool isHS)
+{
+  // unit = cm
+  float space_btw_packs = 1;
+  float space_btw_bars  = 0.2;
+
+  int phys_ch_x = phys_ch[0];
+  int phys_ch_y = phys_ch[1];
+  int phys_ch_z = phys_ch[2];
+
+  float x=-999;
+  float y=-999;
+  float z=-999;
+  float ex=-999;
+  float ey=-999;
+  float ez=-999;
+
+  if(isHS)
+  {
+    // vertical: y=0
+    if(phys_ch_y==0)
+    {
+      // bottom: z>0
+      if(phys_ch_z>0)
+      {
+        // x
+        if(phys_ch_x>0) x = space_btw_packs/2 + 2./2 + (phys_ch_x-1)*2. + (phys_ch_x-1)*0.2;
+        else x = -1*space_btw_packs/2 - 2./2 + (phys_ch_x+1)*2. + (phys_ch_x+1)*0.2;
+        // z
+        z = 180 + 0.5 +  (phys_ch_z-1)*2. + 2./2 + (phys_ch_z-1)*0.2;
+        // y: approximate
+        y=0;
+      }
+      // top: z<0
+      else
+      {
+        // x
+        if(phys_ch_x>0) x = space_btw_packs/2 + 2./2 + (phys_ch_x-1)*2. + (phys_ch_x-1)*0.2;
+        else x = -1*space_btw_packs/2 - 2./2 + (phys_ch_x+1)*2. + (phys_ch_x+1)*0.2;
+        // z
+        z = -180 - 10 - 0.5 + (1+phys_ch_z)*2. - 2./2 + (1+phys_ch_z)*0.2;
+        // y
+        y=0;
+      }
+      //ex = TMath::Sqrt(2.*2./12.);
+      //ey = TMath::Sqrt(45.*45./12.);
+      //ez = TMath::Sqrt(2.*2./12.);
+      ex = TMath::Sqrt(0.2*0.2/12.);
+      ey = TMath::Sqrt(45.*45./12.);
+      ez = TMath::Sqrt(0.2*0.2/12.);
+    }
+    // horizontal: x=0
+    if(phys_ch_x==0)
+    {
+      // y
+      if(phys_ch_y<5) y = -1.25 + (phys_ch_y-1)*2. + (phys_ch_y-1)*0.2;
+      else y = -1.25 + (phys_ch_y-1)*2. + (phys_ch_y-1)*0.2+0.8;
+
+      // bottom: z>0
+      if(phys_ch_z>0)
+      {
+        z = 180 - (2-phys_ch_z)*2. - 2./2 - (2-phys_ch_z)*0.2;
+      }
+      // top: z<0
+      else
+      {
+        z = -180 - 5 + (phys_ch_z+1)*2. - 2./2 + (phys_ch_z+1)*0.2;
+      }
+      x=0;
+      //ex = TMath::Sqrt(45.*45./12.);
+      //ey = TMath::Sqrt(2.*2./12.);
+      //ez = TMath::Sqrt(2.*2./12.);
+      ex = TMath::Sqrt(45.*45./12.);
+      ey = TMath::Sqrt(0.2*0.2/12.);
+      ez = TMath::Sqrt(0.2*0.2/12.);
+    }
+  }
+  else
+  {
+    cout << "TP ... " << endl;
+  }
+
+  std::vector<float> coord_vec;
+  coord_vec.push_back(x);
+  coord_vec.push_back(y);
+  coord_vec.push_back(z);
+  // uncertainty
+  // note that the variance of a flat distribution is l^2/12 where l is the width
+  coord_vec.push_back(ex);
+  coord_vec.push_back(ey);
+  coord_vec.push_back(ez);
+  return coord_vec;
+}
+
+
+void lineInverted(double t, vector<double> parFit, double &x, double &y, double &z)
+{
+  double p[4];
+  // xz
+  //p[0] =  -1.*parFit.at(1)/parFit.at(0);
+  //p[1] =  1./parFit.at(0);
+  p[1] = parFit.at(0);
+  p[0] = parFit.at(1);
+
+  // yz note: parFit.at(3) ==
+
+  //p[2] =  -1.*parFit.at(5)/parFit.at(4);
+  //p[3] =  1./parFit.at(4);
+  p[3] = parFit.at(4);
+  p[2] = parFit.at(5);
+
+  x = p[0] + p[1]*t;
+  y = p[2] + p[3]*t;
+  z = t;
+}
+
+
+
+// track fit
+vector<double> doFit(vector<int> *hs_data)
+{
+  // return this vector
+  vector<double> parFit;
+  parFit.clear();
+
+  if(hs_data->size()<2) return parFit;
+
+  // arrays for fit
+  const int n = hs_data->size();
+  Double_t x[n], y[n], z[n];
+  Double_t ex[n], ey[n], ez[n];
+
+  int n_hs_botver=0;
+  int n_hs_bothor=0;
+  int n_hs_topver=0;
+  int n_hs_tophor=0;
+  int n_hs_bot=0;
+  int n_hs_top=0;
+  for(unsigned int ihs=0; ihs<hs_data->size(); ihs++)
+  {
+    int ch = hs_data->at(ihs);
+    //cout << "hs hits: " << ch << endl;
+    if(ch<16) n_hs_botver++;
+    if(ch>=48) n_hs_topver++;
+    if(ch>=16 && ch<32) n_hs_bothor++;
+    if(ch>=32 && ch<48) n_hs_tophor++;
+    if(ch<32) n_hs_bot++;
+    if(ch>=32) n_hs_top++;
+  }
+
+  bool doTrackFit = false;
+  doTrackFit = n_hs_topver>0 && n_hs_botver>0 && n_hs_tophor>0 && n_hs_bothor>0;
+  //doTrackFit = n_hs_bot>1 && n_hs_top>1;
+
+  if(0)
+  {
+    cout << "Number of top vertical hits:   " << n_hs_topver << endl;
+    cout << "Number of bot vertical hits:   " << n_hs_botver << endl;
+    cout << "Number of top horizontal hits: " << n_hs_tophor << endl;
+    cout << "Number of bot horizontal hits: " << n_hs_bothor << endl;
+    cout << "Perform fit or not:            " << doTrackFit << endl;
+  }
+
+  //
+  if(!doTrackFit) return parFit;
+
+  // 1. convert to physical channels
+  // Hodoscope
+  for(unsigned int i=0; i<hs_data->size(); i++)
+  {
+    std::vector<int> phys_ch = convertRawToPhysCh(hs_data->at(i), true);
+    std::vector<float> coord_ch = convertPhysChToCoord(phys_ch, true);
+    if(0)
+    {
+      cout << hs_data->at(i) << " :: " << phys_ch[0] << " " << phys_ch[1] << " " << phys_ch[2] << endl;
+      cout << coord_ch[0] << " +/- " << coord_ch[3] << endl;
+      cout << coord_ch[1] << " +/- " << coord_ch[4] << endl;
+      cout << coord_ch[2] << " +/- " << coord_ch[5] << endl;
+      cout << endl;
+    }
+
+    //TESTING
+    //if(coord_ch[0] != 0) x[i] = coord_ch[0];
+    //if(coord_ch[1] != 0) y[i] = coord_ch[1];
+    x[i] = coord_ch[0];
+    y[i] = coord_ch[1];
+    z[i] = coord_ch[2];
+    //TESTING
+    //if(coord_ch[0] != 0) ex[i] = coord_ch[3];
+    //if(coord_ch[1] != 0) ey[i] = coord_ch[4];
+    ex[i] = coord_ch[3];
+    ey[i] = coord_ch[4];
+    ez[i] = coord_ch[5];
+    phys_ch.clear();
+    coord_ch.clear();
+  }
+
+  TGraphErrors *g_xz = new TGraphErrors(n, x, z, ex, ez);
+  TF1 *f_xz = new TF1("f_xz","x*[0]+[1]", 1000, -1000);
+  int fit_xz_status = g_xz->Fit("f_xz");
+
+  TGraphErrors *g_yz = new TGraphErrors(n, y, z, ey, ez);
+  TF1 *f_yz = new TF1("f_yz","x*[0]+[1]", 1000, -1000);
+  int fit_yz_status = g_yz->Fit("f_yz");
+
+  if(fit_xz_status==0 || f_xz->GetParameter(0)>10000)
+  {
+    parFit.push_back(f_xz->GetParameter(0));
+    parFit.push_back(f_xz->GetParameter(1));
+  }
+  else{
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+  }
+  if(fit_yz_status==0 || f_yz->GetParameter(0)>10000)
+  {
+    parFit.push_back(f_yz->GetParameter(0));
+    parFit.push_back(f_yz->GetParameter(1));
+  }
+  else
+  {
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+  }
+
+  return parFit;
+}
+//
+void getPathLengthInverted(vector<double> parFit, vector<int> &chan, vector<double> &path_length)
+{
+
+  //   l1          l2          l3
+  // 0    1      6    7      2    3
+  // 24   25     16   17     22   23
+  // 8    9      12   13     4    5
+  double l1_z_center      = 120+10+2;
+  double l2_z_center      = 0+10;
+  double l3_z_center      = -120+10-5;
+  double col_left_center  = -3;
+  double col_right_center = 3;
+  double row1_center      = 0;
+  double row2_center      = 6;
+  double row3_center      = 12;
+
+  int ch[32];
+  for(int i=0; i<32; i++) ch[i]=0;
+
+  //
+  int ndiv = 10000;
+  double t0 = 0;
+  double dt = 200;
+  for(int i=0; i<2*ndiv; i++)
+  {
+    double t = t0 + dt*i/ndiv - dt;
+    double x,y,z;
+    lineInverted(t,parFit,x,y,z);
+
+    // layer1
+    if(z>l1_z_center-40 && z<l1_z_center+40)
+    {
+      // left column
+      if(x>col_left_center-2.5 && x<col_left_center+2.5)
+      {
+        if(y>row3_center-2.5 && y<row3_center+2.5) ch[0]++;   // row3
+        if(y>row2_center-2.5 && y<row2_center+2.5) ch[24]++;  // row2
+        if(y>row1_center-2.5 && y<row1_center+2.5) ch[8]++;   // row1
+      }
+      // right column
+      if(x>col_right_center-2.5 && x<col_right_center+2.5)
+      {
+        if(y>row3_center-2.5 && y<row3_center+2.5) ch[1]++;   // row3
+        if(y>row2_center-2.5 && y<row2_center+2.5) ch[25]++;  // row2
+        if(y>row1_center-2.5 && y<row1_center+2.5) ch[9]++;   // row1
+      }
+    }
+    // layer2
+    if(z>l2_z_center-40 && z<l2_z_center+40)
+    {
+      // left column
+      if(x>col_left_center-2.5 && x<col_left_center+2.5)
+      {
+        if(y>row3_center-2.5 && y<row3_center+2.5) ch[6]++;   // row3
+        if(y>row2_center-2.5 && y<row2_center+2.5) ch[16]++;  // row2
+        if(y>row1_center-2.5 && y<row1_center+2.5) ch[12]++;  // row1
+      }
+      // right column
+      if(x>col_right_center-2.5 && x<col_right_center+2.5)
+      {
+        if(y>row3_center-2.5 && y<row3_center+2.5) ch[7]++;   // row3
+        if(y>row2_center-2.5 && y<row2_center+2.5) ch[17]++;  // row2
+        if(y>row1_center-2.5 && y<row1_center+2.5) ch[13]++;  // row1
+      }
+    }
+    // layer3
+    if(z>l3_z_center-40 && z<l3_z_center+40)
+    {
+      // left column
+      if(x>col_left_center-2.5 && x<col_left_center+2.5)
+      {
+        if(y>row3_center-2.5 && y<row3_center+2.5) ch[2]++;   // row3
+        if(y>row2_center-2.5 && y<row2_center+2.5) ch[22]++;  // row2
+        if(y>row1_center-2.5 && y<row1_center+2.5) ch[4]++;   // row1
+      }
+      // right column
+      if(x>col_right_center-2.5 && x<col_right_center+2.5)
+      {
+        if(y>row3_center-2.5 && y<row3_center+2.5) ch[3]++;   // row3
+        if(y>row2_center-2.5 && y<row2_center+2.5) ch[23]++;  // row2
+        if(y>row1_center-2.5 && y<row1_center+2.5) ch[5]++;   // row1
+      }
+    }
+  }
+
+  for(int i=0; i<32; i++)
+  {
+    if(ch[i]>0)
+    {
+      chan.push_back(i);
+      float delta_z = ch[i]*dt/ndiv;
+      float delta_x = delta_z/parFit.at(0);
+      float delta_y = delta_z/parFit.at(2);
+      path_length.push_back(TMath::Sqrt(delta_x*delta_x+delta_y*delta_y+delta_z*delta_z));
+    }
+  }
+
+}
+
+//
+class hsData
+{
+  private:
+    int   event_mq_;
+    int   epoch_time_;
+    int   us_;
+    std::vector<bool>  data_hs_;
+    std::vector<bool>  data_tp_;
+
+  public:
+    //
+    hsData(int epoch_time, int us, std::vector<bool> data_hs, std::vector<bool> data_tp, int event_mq)
+    {
+      epoch_time_ = epoch_time;
+      us_         = us;
+      event_mq_   = event_mq;
+      for(unsigned int i=0; i<data_hs.size(); i++) data_hs_.push_back(data_hs[i]);
+      for(unsigned int i=0; i<data_tp.size(); i++) data_tp_.push_back(data_tp[i]);
+    }
+    //
+    hsData(TString tstr_data, bool preTS1)
+    {
+      tstr_data.ReplaceAll(" ",":");
+
+      TObjArray *tk_data = tstr_data.Tokenize(":");
+      epoch_time_ =  (static_cast<TObjString*>(tk_data->At(0)))->String().Atoi();
+      us_         =  (static_cast<TObjString*>(tk_data->At(7)))->String().Atoi();
+      // hs data
+      for(int i=38; i<=164; i=i+2)
+      {
+        if(tstr_data[i]=='1') data_hs_.push_back(1);
+        else data_hs_.push_back(0);
+      }
+      // trackpack data
+      for(int i=167; i<=213; i=i+2)
+      {
+        if(tstr_data[i]=='1') data_tp_.push_back(1);
+        else data_tp_.push_back(0);
+      }
+      // extrg
+      if(!preTS1 && tstr_data[216]=='1') event_mq_=1;
+      else event_mq_=0;
+
+      delete tk_data;
+    }
+    //
+    int getEpochTime()            {return epoch_time_;               }
+    double getMicroTime()         {return epoch_time_+0.000001*us_;  }
+    std::vector<bool> getHSData() {return data_hs_;                  }
+    std::vector<bool> getTPData() {return data_tp_;                  }
+    int isMQEvent()               {return event_mq_;  }
+    void printData()
+    {
+      std::cout << epoch_time_+0.000001*us_ << " " << event_mq_ << " ";
+      for(unsigned int i=0; i<data_hs_.size(); i++) std::cout << data_hs_.at(i);
+      std::cout << " " ;
+      for(unsigned int i=0; i<data_tp_.size(); i++) std::cout << data_tp_.at(i);
+      std::cout << std::endl;
+    }
+};
+
+TString kind_str(int kind)
+{
+  if(kind==-1) return "previous";
+  else if(kind==1) return "next";
+  else return "current";
+}
+
+void loadHSDataTree(TString hs_file_dir, TString hs_file, std::vector<hsData> &hsDataLoaded, int kind, bool preTS1=false)
+{
+  ifstream fin(Form("%s/%s", hs_file_dir.Data(), hs_file.Data()));
+  // cout << (Form("Loading %s HS file: %s/%s", kind_str(kind).Data(), hs_file_dir.Data(), hs_file.Data())) << endl;
+
+  // Get the number of events
+  int nLines=-1;
+  string s;
+  if(fin.is_open())
+  {
+    while(fin.good())
+    {
+      getline(fin, s);
+      nLines++;
+    }
+  }
+  // cout << "Number of lines: " << nLines << endl;
+  fin.close();
+
+  // Add events to memory
+  ifstream finfile(Form("%s/%s", hs_file_dir.Data(), hs_file.Data()));
+  int line=0;
+  if(finfile.is_open())
+  {
+    while(finfile.good())
+    {
+      // get a line from finfile
+      getline(finfile, s);
+      line++;
+
+      if(line>nLines) break;
+
+      if(kind==-1 && line<nLines*0.9) continue;
+      if(kind==1 && line>nLines*0.1) break;
+
+      hsData hsDataOne(static_cast<TString>(s), preTS1);
+      hsDataLoaded.push_back(hsDataOne);
+    }
+  }
+  finfile.close();
+}
+
+void loadHSData(TString hs_file_dir, TString hs_file, std::vector<hsData> &hsDataLoaded, int kind, bool preTS1=false)
+{
+  ifstream fin(Form("%s/%s", hs_file_dir.Data(), hs_file.Data()));
+  // cout << (Form("Loading %s HS file: %s/%s", kind_str(kind).Data(), hs_file_dir.Data(), hs_file.Data())) << endl;
+
+  // Get the number of events
+  int nLines=-1;
+  string s;
+  if(fin.is_open())
+  {
+    while(fin.good())
+    {
+      getline(fin, s);
+      nLines++;
+    }
+  }
+  // cout << "Number of lines: " << nLines << endl;
+  fin.close();
+
+  // Add events to memory
+  ifstream finfile(Form("%s/%s", hs_file_dir.Data(), hs_file.Data()));
+  int line=0;
+  if(finfile.is_open())
+  {
+    while(finfile.good())
+    {
+      // get a line from finfile
+      getline(finfile, s);
+      line++;
+
+      if(line>nLines) break;
+
+      if(kind==-1 && line<nLines*0.9) continue;
+      if(kind==1 && line>nLines*0.1) break;
+
+      hsData hsDataOne(static_cast<TString>(s), preTS1);
+      hsDataLoaded.push_back(hsDataOne);
+    }
+  }
+  finfile.close();
+}
+
+
+vector<double> doCircleFit(vector<int> * hs_data)
+{
+  // return this vector
+  vector<double> parFit;
+  parFit.clear();
+
+  if(hs_data->size()<2) return parFit;
+
+  // arrays for fit
+  const int n = hs_data->size();
+  Double_t x[n], y[n], z[n];
+  Double_t ex[n], ey[n], ez[n];
+
+  int n_hs_botver=0;
+  int n_hs_bothor=0;
+  int n_hs_topver=0;
+  int n_hs_tophor=0;
+  int n_hs_bot=0;
+  int n_hs_top=0;
+  for(unsigned int ihs=0; ihs<hs_data->size(); ihs++)
+  {
+    int ch = hs_data->at(ihs);
+    //cout << "hs hits: " << ch << endl;
+    if(ch<16) n_hs_botver++;
+    if(ch>=48) n_hs_topver++;
+    if(ch>=16 && ch<32) n_hs_bothor++;
+    if(ch>=32 && ch<48) n_hs_tophor++;
+    if(ch<32) n_hs_bot++;
+    if(ch>=32) n_hs_top++;
+  }
+
+  bool doTrackFit = false;
+  doTrackFit = n_hs_topver>0 && n_hs_botver>0 && n_hs_tophor>0 && n_hs_bothor>0;
+  //doTrackFit = n_hs_bot>1 && n_hs_top>1;
+
+  if(0)
+  {
+    cout << "Number of top vertical hits:   " << n_hs_topver << endl;
+    cout << "Number of bot vertical hits:   " << n_hs_botver << endl;
+    cout << "Number of top horizontal hits: " << n_hs_tophor << endl;
+    cout << "Number of bot horizontal hits: " << n_hs_bothor << endl;
+    cout << "Perform fit or not:            " << doTrackFit << endl;
+  }
+
+  //
+  if(!doTrackFit) return parFit;
+
+  // 1. convert to physical channels
+  // Hodoscope
+  for(unsigned int i=0; i<hs_data->size(); i++)
+  {
+    std::vector<int> phys_ch = convertRawToPhysCh(hs_data->at(i), true);
+    std::vector<float> coord_ch = convertPhysChToCoord(phys_ch, true);
+    if(0)
+    {
+      cout << hs_data->at(i) << " :: " << phys_ch[0] << " " << phys_ch[1] << " " << phys_ch[2] << endl;
+      cout << coord_ch[0] << " +/- " << coord_ch[3] << endl;
+      cout << coord_ch[1] << " +/- " << coord_ch[4] << endl;
+      cout << coord_ch[2] << " +/- " << coord_ch[5] << endl;
+      cout << endl;
+    }
+    x[i] = coord_ch[0];
+    y[i] = coord_ch[1];
+    z[i] = coord_ch[2];
+    ex[i] = coord_ch[3];
+    ey[i] = coord_ch[4];
+    ez[i] = coord_ch[5];
+    phys_ch.clear();
+    coord_ch.clear();
+  }
+
+  TGraphErrors *g_xz = new TGraphErrors(n, x, z, ex, ez);
+  TF1 *f_xz = new TF1("f_xz","x*[0]+[1]", 1000, -1000);
+  int fit_xz_status = g_xz->Fit("f_xz", "q");
+
+  TGraphErrors *g_yz = new TGraphErrors(n, y, z, ey, ez);
+  TF1 *f_yz = new TF1("f_yz","x*[0]+[1]", 1000, -1000);
+  int fit_yz_status = g_yz->Fit("f_yz", "q");
+
+  if(fit_xz_status==0 || f_xz->GetParameter(0)>10000)
+  {
+    parFit.push_back(f_xz->GetParameter(0));
+    parFit.push_back(f_xz->GetParameter(1));
+    parFit.push_back(f_xz->GetParError(0));
+    parFit.push_back(f_xz->GetParError(1));
+  }
+  else{
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+  }
+  if(fit_yz_status==0 || f_yz->GetParameter(0)>10000)
+  {
+    parFit.push_back(f_yz->GetParameter(0));
+    parFit.push_back(f_yz->GetParameter(1));
+    parFit.push_back(f_yz->GetParError(0));
+    parFit.push_back(f_yz->GetParError(1));
+  }
+  else
+  {
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+  }
+
+  return parFit;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+bool equalDoubles(double a, double b, double epsilon = 1e-320){
+    return abs(a - b) <= epsilon;
+}
+
+int checkIntervalOverlap(double min1Temp, double max1Temp, double min2Temp, double max2Temp) {
+  // 0 == intervals don't overlap
+  // 1 == intervals overlap but not contained within each other
+  // 2 == interval 2 inside 1
+  // 3 == interval 1 inside 2
+  // 4 == same interval 
+
+  double min1(min1Temp), max1(max1Temp), min2(min2Temp), max2(max2Temp);
+  // if intervals not ordered, order them:
+  if(max1 < min1){ min1Temp = max1; max1Temp = min1; }
+  if(max2 < min2){ min2Temp = max2; max2Temp = min2; }
+
+  int intervalStatus = 0;
+
+  // check if either interval is a point:
+  bool point1 = equalDoubles(min1, max1);
+  bool point2 = equalDoubles(min2, max2);
+
+  if(point1 && !point2){
+    if(min1 > min2 && min1 < max2) intervalStatus = 1;
+    if(equalDoubles(min1, min2)||equalDoubles(min1, max2)) intervalStatus = 4;
+  }
+  else if(!point1 && point2){
+    if(min2 > min1 && min2 < max1) intervalStatus = 1;
+    if(equalDoubles(min2, min1)||equalDoubles(min2, max1)) intervalStatus = 4;
+  }
+  else if(point1 && point2){
+    if(equalDoubles(min1, min2)) intervalStatus = 4;
+  }
+  else{
+    // intervals overlap but not inside
+    if(equalDoubles(max1, min2) &&  min1 < min2 && max2 > min2) intervalStatus = 1;
+    else if(equalDoubles(max2, min1) && min2 < min1) intervalStatus = 1;
+    else if(min1 > min2 && min1 < max2 && max1 > max2) intervalStatus = 1;
+    else if(min2 > min1 && min2 < max1 && max2 > max1) intervalStatus = 1;
+
+    // interval 2 inside 1
+    if(min2 > min1 && min2 < max1 && max2 > min1 && max2 < max1) intervalStatus = 2;
+    else if(equalDoubles(min1, min2) && max2 < max1) intervalStatus = 2;
+    else if(equalDoubles(max1, max2) && min2 > min1) intervalStatus = 2;
+
+    // interval 1 inside 2
+    if(min1 > min2 && min1 < max2 && max1 > min2 && max1 < max2) intervalStatus = 3;
+    else if(equalDoubles(min1, min2) && max1 < max2) intervalStatus = 3;
+    else if(equalDoubles(max1, max2) && min1 > min2) intervalStatus = 3;
+
+    // intervals equal
+    if(equalDoubles(min1, min2) && equalDoubles(max1, max2)) intervalStatus = 4;
+  }
+  
+  return intervalStatus;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////// Inverted Stuff
+
+void getCirclePathLengthInverted(vector<double> parFit, vector<int> &chan, vector<double> &path_length, int runFit, int fileFit, int eventFit, string stringFit, bool& mathematicaRequired, bool weighted)
+{
+  bool testing = false;
+
+  bool parFitGood = true;
+  if(parFit.size() == 0) return;
+
+  for(auto i:parFit){
+    if(abs(-1 - i) < 5e-324) parFitGood = false;
+  }
+
+  if(!parFitGood) return;
+
+  //   l1          l2          l3
+  // 0    1      6    7      2    3
+  // 24   25     16   17     22   23
+  // 8    9      12   13     4    5
+  double l1_z_center      = 120+10+2;
+  double l2_z_center      = 0+10;
+  double l3_z_center      = -120+10-5;
+  double col_left_center  = -3;
+  double col_right_center = 3;
+  double row1_center      = 0;
+  double row2_center      = 6;
+  double row3_center      = 12;
+
+  vector<int> ch(32,0);
+
+  //
+  int ndiv = 150;
+  double t0 = 0;
+  double dt = 200;
+
+  ofstream fout;
+  // ofstream foutNoMath;
+  if(!testing){
+    fout.open(stringFit, std::ios_base::app);
+    // foutNoMath.open(stringFit+"noMath.txt", std::ios_base::app);
+  }
+
+
+  for(int i=0; i<2*ndiv; i++)
+  {
+    vector<int> tempCh(32,0);
+
+    double t = t0 + dt*i/ndiv - dt;
+    double x,y,z;
+
+    lineInverted(t,parFit,x,y,z);
+
+    // indices 2,3 are xz errors, 6,7 are yz errors
+    double xInterceptError = parFit[3];
+    double xSlopeError = parFit[2];
+    double yInterceptError = parFit[7];
+    double ySlopeError = parFit[6];
+
+    //half of the error
+    //error given by distance between max slope error  and max yint slope
+    double x_axis_length = sqrt(pow(z,2)*pow(xSlopeError,2) + pow(xInterceptError, 2));
+    double y_axis_length = sqrt(pow(z,2)*pow(ySlopeError,2) + pow(yInterceptError, 2));
+
+    //cout << "{Ellipsoid[{" << x << ", " << y << ", " <<  z << "},{" << x_axis_length << ", " << y_axis_length << ",0}]}, " << endl;
+
+    int axesInsideSquare = 0;
+    int layer = -1;
+    vector<int> rows = {};
+    vector<int> cols = {};
+
+    // layers
+    if(z>l1_z_center-40 && z<l1_z_center+40) layer = 1;
+    if(z>l2_z_center-40 && z<l2_z_center+40) layer = 2;
+    if(z>l3_z_center-40 && z<l3_z_center+40) layer = 3;
+
+    //cols
+    if(weighted){
+      int col1Status = checkIntervalOverlap(x-x_axis_length, x+x_axis_length, col_left_center - 2.5, col_left_center + 2.5);
+      int col2Status = checkIntervalOverlap(x-x_axis_length, x+x_axis_length, col_right_center - 2.5, col_right_center +2.5);
+      if(col1Status > 0) cols.push_back(1);
+      if(col2Status > 0) cols.push_back(2);
+      if(col1Status == 3 || col2Status == 3) ++axesInsideSquare;
+    }
+    else{
+      int col1Status = checkIntervalOverlap(x, x, col_left_center - 2.5, col_left_center + 2.5);
+      int col2Status = checkIntervalOverlap(x, x, col_right_center - 2.5, col_right_center +2.5);
+      if(col1Status > 0) cols.push_back(1);
+      if(col2Status > 0) cols.push_back(2);
+    }
+
+    //rows
+    if(weighted){
+      int row1Status = checkIntervalOverlap(y-y_axis_length, y+y_axis_length, row1_center - 2.5, row1_center +2.5);
+      int row2Status = checkIntervalOverlap(y-y_axis_length, y+y_axis_length, row2_center - 2.5, row2_center +2.5);
+      int row3Status = checkIntervalOverlap(y-y_axis_length, y+y_axis_length, row3_center - 2.5, row3_center +2.5);
+      if(row1Status > 0) rows.push_back(1);
+      if(row2Status > 0) rows.push_back(2);
+      if(row3Status > 0) rows.push_back(3);
+      if(row1Status == 3 || row2Status == 3 || row3Status == 3) ++axesInsideSquare;
+    }
+    else{
+      int row1Status = checkIntervalOverlap(y, y, row1_center - 2.5, row1_center +2.5);
+      int row2Status = checkIntervalOverlap(y, y, row2_center - 2.5, row2_center +2.5);
+      int row3Status = checkIntervalOverlap(y, y, row3_center - 2.5, row3_center +2.5);
+      if(row1Status > 0) rows.push_back(1);
+      if(row2Status > 0) rows.push_back(2);
+      if(row3Status > 0) rows.push_back(3);
+    }
+
+    if(layer > 0 && rows.size() != 0 && cols.size() != 0){
+      for(auto c:cols){
+        for(auto r:rows){
+          //cout << "l: "<< layer << " c: " << c << " r: " << r << endl;
+          //cout << "ch: " << channelMap[layer][c][r] << endl;
+          tempCh[channelMap[layer-1][c-1][r-1]] = 1;
+        }
+      }
+    }
+
+    mathematicaRequired = false;
+    bool channelHit = false;
+    for(int i=0; i<32; ++i) if(tempCh[i]>0) channelHit = true;
+    for(int i=0; i<32; ++i) if(tempCh[i]>0) ch[i] = 1;
+   
+    if(channelHit && !testing && axesInsideSquare < 2 && weighted){
+      mathematicaRequired = true;
+      fout << runFit << " " << fileFit << " " << eventFit << " " << x << " " << y << " " << z << " " << x_axis_length << " " << y_axis_length << endl;
+    }
+
+    if(!mathematicaRequired && channelHit){
+      // foutNoMath << "Run " << runFit <<  " File " << fileFit <<  " Event "  << eventFit << " Channels {";
+      fout << "Run " << runFit <<  " File " << fileFit <<  " Event "  << eventFit << " Channels {";
+      bool printedChan = false;
+
+      for(unsigned int t=0;t<tempCh.size(); ++t){
+        if(tempCh[t] > 0){
+          if(printedChan) fout << ", " << t;
+          else{
+            fout << " " << t;
+            printedChan = true;
+          }
+          fout << "} Ratios {1.}" << endl;
+        }
+      }
+    } // end line loop
+  }
+  fout.close();
+  // foutNoMath.close();
+
+
+  for(int i=0; i<32; i++)
+  {
+    if(ch[i]>0)
+    {
+      chan.push_back(i);
+      float delta_z = ch[i]*dt/ndiv;
+      float delta_x = delta_z/parFit.at(0);
+      float delta_y = delta_z/parFit.at(2);
+      path_length.push_back(TMath::Sqrt(delta_x*delta_x+delta_y*delta_y+delta_z*delta_z));
+    }
+  }
+
+
+}
+
+
+
+
+vector<double> doCircleFitInverted(vector<int> * hs_data)
+{
+  // return this vector
+  vector<double> parFit;
+  parFit.clear();
+
+  if(hs_data->size()<2) return parFit;
+
+  // arrays for fit
+  const int n = hs_data->size();
+  Double_t x[n], y[n], z[n];
+  Double_t ex[n], ey[n], ez[n];
+
+  int n_hs_botver=0;
+  int n_hs_bothor=0;
+  int n_hs_topver=0;
+  int n_hs_tophor=0;
+  int n_hs_bot=0;
+  int n_hs_top=0;
+  for(unsigned int ihs=0; ihs<hs_data->size(); ihs++)
+  {
+    int ch = hs_data->at(ihs);
+    //cout << "hs hits: " << ch << endl;
+    if(ch<16) n_hs_botver++;
+    if(ch>=48) n_hs_topver++;
+    if(ch>=16 && ch<32) n_hs_bothor++;
+    if(ch>=32 && ch<48) n_hs_tophor++;
+    if(ch<32) n_hs_bot++;
+    if(ch>=32) n_hs_top++;
+  }
+
+  bool doTrackFit = false;
+  doTrackFit = n_hs_topver>0 && n_hs_botver>0 && n_hs_tophor>0 && n_hs_bothor>0;
+  //doTrackFit = n_hs_bot>1 && n_hs_top>1;
+
+  if(0)
+  {
+    cout << "Number of top vertical hits:   " << n_hs_topver << endl;
+    cout << "Number of bot vertical hits:   " << n_hs_botver << endl;
+    cout << "Number of top horizontal hits: " << n_hs_tophor << endl;
+    cout << "Number of bot horizontal hits: " << n_hs_bothor << endl;
+    cout << "Perform fit or not:            " << doTrackFit << endl;
+  }
+
+  //
+  if(!doTrackFit) return parFit;
+
+  // 1. convert to physical channels
+  // Hodoscope
+  for(unsigned int i=0; i<hs_data->size(); i++)
+  {
+    std::vector<int> phys_ch = convertRawToPhysCh(hs_data->at(i), true);
+    std::vector<float> coord_ch = convertPhysChToCoord(phys_ch, true);
+    if(coord_ch.size() < 6) continue;
+    x[i] = coord_ch[0];
+    y[i] = coord_ch[1];
+    z[i] = coord_ch[2];
+    ex[i] = coord_ch[3];
+    ey[i] = coord_ch[4];
+    ez[i] = coord_ch[5];
+    phys_ch.clear();
+    coord_ch.clear();
+  }
+
+  // NOTE: x and z are switched
+  TGraphErrors *g_xz = new TGraphErrors(n, z, x, ez, ex);
+  TF1 *f_xz = new TF1("f_xz","x*[0]+[1]", 1000, -1000);
+  int fit_xz_status = g_xz->Fit("f_xz", "q");
+
+  // NOTE: y and z switched
+  TGraphErrors *g_yz = new TGraphErrors(n, z, y, ez, ey);
+  TF1 *f_yz = new TF1("f_yz","x*[0]+[1]", 1000, -1000);
+  int fit_yz_status = g_yz->Fit("f_yz", "q");
+
+  if(fit_xz_status==0 || f_xz->GetParameter(0)>10000)
+  {
+    parFit.push_back(f_xz->GetParameter(0));
+    parFit.push_back(f_xz->GetParameter(1));
+    parFit.push_back(f_xz->GetParError(0));
+    parFit.push_back(f_xz->GetParError(1));
+  }
+  else{
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+  }
+  if(fit_yz_status==0 || f_yz->GetParameter(0)>10000)
+  {
+    parFit.push_back(f_yz->GetParameter(0));
+    parFit.push_back(f_yz->GetParameter(1));
+    parFit.push_back(f_yz->GetParError(0));
+    parFit.push_back(f_yz->GetParError(1));
+  }
+  else
+  {
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+    parFit.push_back(-1);
+  }
+
+  return parFit;
+}
+
+
+void getCirclePathLengthInverted(vector<double> parFit, vector<int> &chan, vector<double> &path_length)
+{
+
+  bool parFitGood = true;
+  for(auto i:parFit){
+    if(abs(-1 - i) < 5e-324) parFitGood = false;
+    }
+  if(!parFitGood) return;
+
+
+  //   l1          l2          l3
+  // 0    1      6    7      2    3
+  // 24   25     16   17     22   23
+  // 8    9      12   13     4    5
+  double l1_z_center      = 120+10+2;
+  double l2_z_center      = 0+10;
+  double l3_z_center      = -120+10-5;
+  double col_left_center  = -3;
+  double col_right_center = 3;
+  double row1_center      = 0;
+  double row2_center      = 6;
+  double row3_center      = 12;
+
+  int ch[32];
+  for(int i=0; i<32; i++) ch[i]=0;
+
+  //
+  int ndiv = 10000;
+  double t0 = 0;
+  double dt = 200;
+
+  // TH2D * h2int = new TH2D("h2int", "h2int", 1e6, -1e6, 1e6,  1e6, -1e6, 1e6);
+  // TH2D * h2slope = new TH2D("h2slope", "h2slope", 1e6, -1e6, 1e6,  1e6, -1e6, 1e6);
+
+  // cout << "PARFIT: ";
+  // for(unsigned int iP=0; iP<parFit.size(); ++iP) cout << parFit[iP] << " ";
+  // cout << endl;
+
+  for(int i=0; i<2*ndiv; i++)
+  {
+    double t = t0 + dt*i/ndiv - dt;
+    double x(0), y(0), z(0);
+    lineInverted(t,parFit,x,y,z);
+
+    // indices 2,3 are xz errors, 6,7 are yz errors
+    double xInterceptError = parFit[3];
+    double xSlopeError = parFit[2];
+    double yInterceptError = parFit[7];
+    double ySlopeError = parFit[6];
+
+
+    //h2int->Fill(parFit[3]/parFit[1],parFit[7]/parFit[5]);
+    //h2slope->Fill(parFit[2]/parFit[0],  parFit[6]/parFit[4]);
+    //half of the error
+    //error given by distance between max slope error  and max yint slope
+    double x_axis_length = sqrt(pow(z,2)*pow(xSlopeError,2) + pow(xInterceptError, 2));
+    double y_axis_length = sqrt(pow(z,2)*pow(ySlopeError,2) + pow(yInterceptError, 2));
+
+
+    //cout << "{Ellipsoid[{" << x << ", " << y << ", " <<  z << "},{" << x_axis_length << ", " << y_axis_length << ",0}]}, " << endl;
+
+
+    // layer1
+    if(z>l1_z_center-40 && z<l1_z_center+40)
+    {
+      // left column
+      //if(x>col_left_center-2.5 && x<col_left_center+2.5)
+      if(abs(x - col_left_center) < (2.5 + x_axis_length))
+      {
+        if(abs(y - row3_center) < (2.5 + y_axis_length)) ch[0]++;   // row3
+        if(abs(y - row2_center) < (2.5 + y_axis_length)) ch[24]++;  // row2
+        if(abs(y - row1_center) < (2.5 + y_axis_length)) ch[8]++;   // row1
+      }
+      // right column
+      if(abs(x - col_right_center) < (2.5 + x_axis_length))
+      {
+        if(abs(y - row3_center) < (2.5 + y_axis_length)) ch[1]++;   // row3
+        if(abs(y - row2_center) < (2.5 + y_axis_length)) ch[25]++;  // row2
+        if(abs(y - row1_center) < (2.5 + y_axis_length)) ch[9]++;   // row1
+      }
+    }
+    // layer2
+    if(z>l2_z_center-40 && z<l2_z_center+40)
+    {
+      // left column
+      if(abs(x - col_left_center) < (2.5 + x_axis_length))
+      {
+        if(abs(y - row3_center) < (2.5 + y_axis_length)) ch[6]++;   // row3
+        if(abs(y - row2_center) < (2.5 + y_axis_length)) ch[16]++;  // row2
+        if(abs(y - row1_center) < (2.5 + y_axis_length)) ch[12]++;  // row1
+      }
+      // right column
+      if(abs(x - col_right_center) < (2.5 + x_axis_length))
+      {
+        if(abs(y - row3_center) < (2.5 + y_axis_length)) ch[7]++;   // row3
+        if(abs(y - row2_center) < (2.5 + y_axis_length)) ch[17]++;  // row2
+        if(abs(y - row1_center) < (2.5 + y_axis_length)) ch[13]++;  // row1
+      }
+    }
+    // layer3
+    if(z>l3_z_center-40 && z<l3_z_center+40)
+    {
+      // left column
+      if(abs(x - col_left_center) < (2.5 + x_axis_length))
+      {
+        if(abs(y - row3_center) < (2.5 + y_axis_length)) ch[2]++;   // row3
+        if(abs(y - row2_center) < (2.5 + y_axis_length)) ch[22]++;  // row2
+        if(abs(y - row1_center) < (2.5 + y_axis_length)) ch[4]++;   // row1
+      }
+      // right column
+      if(abs(x - col_right_center) < (2.5 + x_axis_length))
+      {
+        if(abs(y - row3_center) < (2.5 + y_axis_length)) ch[3]++;   // row3
+        if(abs(y - row2_center) < (2.5 + y_axis_length)) ch[23]++;  // row2
+        if(abs(y - row1_center) < (2.5 + y_axis_length)) ch[5]++;   // row1
+      }
+    }
+  }
+
+  for(int i=0; i<32; i++)
+  {
+    if(ch[i]>0)
+    {
+      chan.push_back(i);
+      float delta_z = ch[i]*dt/ndiv;
+      float delta_x = delta_z/parFit.at(0);
+      float delta_y = delta_z/parFit.at(2);
+      path_length.push_back(TMath::Sqrt(delta_x*delta_x+delta_y*delta_y+delta_z*delta_z));
+    }
+  }
+
+}
+
+
+
+vector<double> convertBarChToPhysCoord(int barCh){
+    vector<int> row3 = {0,1,6,7,2,3};
+    vector<int> row2 = {24,25, 16,17, 22,23};
+    vector<int> row1 = {8,9,12,13,4,5};
+
+    double x=-999;
+    double y=-999;
+    for(auto b:row1){
+      if(barCh == b) y = 0;
+    }
+   for(auto b:row2){
+      if(barCh == b) y = 6;
+    }
+    for(auto b:row3){
+      if(barCh == b) y = 12;
+    }
+    if(barCh % 2 == 0) x = -3;
+    else x = 3;
+
+    vector<double> coords = {x,y};
+    return coords;
+}
+
+vector<double> calcIntervalErrors(TH1D * hPassArg,TH1D * hTotalArg){
+    vector<double> errorBounds = {-1,-1};
+    TGraphAsymmErrors * effGraph = new TGraphAsymmErrors(hPassArg, hTotalArg);
+    errorBounds = {effGraph->GetErrorYlow(0),effGraph->GetErrorYhigh(0)};
+    return errorBounds;
+    }


### PR DESCRIPTION
Scripts for mixing ntuplized data and hodoscope data from RPi. Original synching method by Jae. `add_hsdata.cpp` mixes hodoscope data and tuples for 1 run. Use the wrapper to run over a full run, etc: 
`python add_hsdata_wrapper.py`
This script contains `utilities.h` and `treesV19Template.h` as dependencies. Lines 47-54 (of add_hsdata.cpp) must be changed according to the desired input/output directories.

Note that this script also creates a new branch in the ntuples for the nPE corrections from UCSB, it can be accessed through the branch `nPECorr`