### PR TITLE
Add DAQEventNumber and TriggerBoard event number to offline tree

### DIFF
--- a/Run3Detector/interface/OfflineFactory.h
+++ b/Run3Detector/interface/OfflineFactory.h
@@ -74,6 +74,7 @@ struct offline_tree_{
     bool beam;
     bool hardNoBeam;
     bool boardsMatched;
+    int DAQEventNumber;
 
     //pulse vectors
     vector<int> v_npulses;
@@ -141,6 +142,7 @@ struct offline_tree_{
     float tMatchingTimeCut;
     int tEvtNum;
     int tRunNum;
+    int tTBEvent;
     //Trigger tree members
 };
 //Offline factory class used to produce offline tree output
@@ -235,6 +237,7 @@ class OfflineFactory {
         float tMatchingTimeCut = -1.;
 	int tEvtNum = 0;
 	int tRunNum = 0;
+        int tTBEvent = 0;
     
 };
 #endif

--- a/Run3Detector/src/OfflineFactory.cc
+++ b/Run3Detector/src/OfflineFactory.cc
@@ -58,8 +58,9 @@ void OfflineFactory::addFriendTree(){
     inTree->SetBranchAddress("trigger", &tTrigger);
     inTree->SetBranchAddress("timeDiff", &tTimeDiff);
     inTree->SetBranchAddress("matchingTimeCut", &tMatchingTimeCut);
-    inTree->SetBranchAddress("evtNum", &tEvtNum);
+    inTree->SetBranchAddress("eventNum", &tEvtNum);
     inTree->SetBranchAddress("runNum", &tRunNum);
+    inTree->SetBranchAddress("tbEvent", &tTBEvent);
 }
 
 // OfflineFactory::~OfflineFactory() {
@@ -257,6 +258,7 @@ void OfflineFactory::prepareOutBranches(){
     outTree->Branch("runNumber",&outputTreeContents.runNumber);
     outTree->Branch("fileNumber",&outputTreeContents.fileNumber);
     outTree->Branch("boardsMatched", &outputTreeContents.boardsMatched);
+    outTree->Branch("DAQEventNumber", &outputTreeContents.DAQEventNumber);
 
     // May need to change for DRS input
     outTree->Branch("triggerThreshold",&outputTreeContents.v_triggerThresholds);
@@ -310,6 +312,7 @@ void OfflineFactory::prepareOutBranches(){
     outTree->Branch("tMatchingTimeCut", &outputTreeContents.tMatchingTimeCut);
     outTree->Branch("tEvtNum", &outputTreeContents.tEvtNum);
     outTree->Branch("tRunNum", &outputTreeContents.tRunNum);
+    outTree->Branch("tTBEvent", &outputTreeContents.tTBEvent);
 }
 //Clear vectors and reset 
 void OfflineFactory::resetOutBranches(){
@@ -1209,6 +1212,8 @@ vector<vector<pair<float,float>>> OfflineFactory::readWaveDataPerEvent(int i){
         //Pulse finding
         allPulseBounds.push_back(processChannel(ic));
     }   
+
+    outputTreeContents.DAQEventNumber = evt->DAQEventNumber;
     
     return allPulseBounds;
 }
@@ -1259,6 +1264,7 @@ void OfflineFactory::readWaveData(){
 	outputTreeContents.tMatchingTimeCut = tMatchingTimeCut;
 	outputTreeContents.tEvtNum = tEvtNum;
 	outputTreeContents.tRunNum = tRunNum;
+    outputTreeContents.tTBEvent = tTBEvent;
         outTree->Fill();
 	//Totally necessary progress bar
 	float progress = 1.0*i/maxEvents; 


### PR DESCRIPTION
This update adds the DAQEventNumber and the trigger board event numbers to the offline tree. I found the DAQEventNumber useful when I wanted to make an event display of an event. By finding the DAQEventNumber I could easily find the file, event numbers. 

The trigger board event number is the event number of event in the TriggerBoard files. Again this is useful to have for debugging. It may be unnecessary to have the eventNum and runNum saved in the offline trees. These numbers could be used as checks to ensure that the MilliQan and MatchedEvents trees are in sync (DAQEventNumber could also do this).