### PR TITLE
DQM Directory and MilliQan Processor

### DIFF
--- a/Run3Detector/analysis/DQM/checkMatching.py
+++ b/Run3Detector/analysis/DQM/checkMatching.py
@@ -1,0 +1,267 @@
+import os
+import ROOT as r
+import uproot
+import time
+import argparse
+import pandas as pd
+from datetime import datetime
+import numpy as np
+import json
+
+class runInfo:
+    
+    def __init__(self):
+        
+        self.run = -1
+        self.file = -1
+        self.rawDirectory = None
+        self.offlineDirectory = None
+        self.daqFile = None
+        self.trigFile = None
+        self.matchFile = None
+        self.offlineFile = None
+        self.totalEvents = -1
+        self.unmatchedEvents = -1
+        self.startTime = -1
+        self.unmatchedBoards = -1
+        self.daqCTime = None
+        self.trigCTime = None
+        self.matchCTime = None
+        self.offlineCTime = None
+    
+    def __str__(self):
+        out = 'run: {0} file: {1}\n\t\
+               daqFile: {2}\n\t\
+               trigFile: {3}\n\t\
+               matchFile: {4}\n\t\
+               offlineFile: {5}'.format(self.run, self.file, self.daqFile, self.trigFile, self.matchFile, self.offlineFile)
+        return out
+        
+
+class fileChecker():
+    
+    def __init__(self):
+        self.min_run = 1022
+        self.max_run = 1123
+        self.rawDir = ''
+        self.offlineDir = ''
+        
+        self.parse_args()
+        if self.args.rawDir: self.rawDir = self.args.rawDir
+        if self.args.offlineDir: self.offlineDir = self.args.offlineDir
+            
+        self.initializePlots()
+
+        self.daqFiles = {}
+        self.trigFiles = {}
+        self.matchedFiles = {}
+        self.offlineFiles = {}
+        
+        self.runInfos = pd.DataFrame(columns=['run', 'file', 'rawDir', 'offlineDir', 'daqFile', 'trigFile',
+                                  'matchFile', 'offlineFile', 'totalEvents', 'unmatchedEvents', 
+                                  'startTime', 'unmatchedBoards', 'daqCTime', 'trigCTime', 'matchCTime',
+                                  'offlineCTime'])
+        #self.runInfos.set_index(['run', 'file'], inplace=True)
+        
+        self.debug = False
+        
+        self.rawDirs = rawDirectories = ['1000', '1100']
+        self.subRawDirs = ['0001', '0002', '0003', '0004', '0005', '0006', '0007', '0008', '0009']
+        
+    def parse_args(self):
+        parser=argparse.ArgumentParser()
+        parser.add_argument("-r", "--rawDir", type=str, default = '/store/user/milliqan/run3/', help="Raw data directory")
+        parser.add_argument("-o", "--offlineDir", type=str, default = '/store/user/milliqan/trees/v33/bar/', help="Offline data directory")
+        self.args = parser.parse_args(args=[])
+
+    def initializePlots(self):
+
+        bins = self.max_run - self.min_run
+        self.h_total = r.TH1F("h_total", "Total Number of Events in Run", bins, self.min_run, self.max_run)
+        self.h_unmatched = r.TH1F("h_unmatched", "Number of Unmatched Events in Run", bins, self.min_run, self.max_run)
+        self.h_startTimes = r.TH1F("h_startTimes", "Start Times of Runs", bins, self.min_run, self.max_run)
+        self.h_boardUnmatched = r.TH1F("h_boardUnmatched", "Number of Boards Unmatched", bins, self.min_run, self.max_run)
+
+        self.c1  = r.TCanvas("c1", "c1", 800,800)
+        
+        
+    def checkOfflineFiles(self, fileList):
+
+        total_unmatched = 0
+        for events in uproot.iterate(
+
+            #files
+            fileList,
+
+            #branches
+            ['runNumber', 'fileNumber', 'boardsMatched'],
+
+            #cut
+            #cut="",
+
+            how="zip",
+
+            step_size=1000,
+
+            num_workers=8,
+
+            ):
+
+            unmatchedCut = events[:, "boardsMatched"] == 0
+            unmatched = events[unmatchedCut, "boardsMatched"]
+            self.h_boardUnmatched.Fill(events[0, 'runNumber'], len(unmatched))
+            
+            self.runInfos['unmatchedBoards'].loc[(self.runInfos['run'] == events[0, 'runNumber']) & (self.runInfos['file'] == events[0, 'fileNumber'])] += len(unmatched)
+    
+    def getRunFile(self, filename):
+        runNum = filename.split('Run')[-1].split('.')[0]
+        fileNum = filename.split('.')[1].split('_')[0]
+        return runNum, fileNum
+    
+    
+    def saveJson(self, name):
+        self.runInfos.to_json(name, orient = 'split', compression = 'infer', index = 'true')
+        
+    def loadJson(self, jsonFile):
+        fin = open(jsonFile)
+        data = json.load(fin)
+        self.runInfos = pd.DataFrame(data['data'], columns=data['columns'])
+    
+    def checkMatchedFiles(self, fileList):
+        total_unmatched = 0
+        for events in uproot.iterate(
+
+            #files
+            fileList,
+
+            #branches
+            ['runNum', 'eventNum', 'trigger', 'startTime'],
+
+
+            #needs to be 1000 events for file number to be correct
+            step_size=1000,
+
+            num_workers=8,
+            
+        ):
+
+            unmatchedCut = events[:, "trigger"] == -1
+            unmatched = events[unmatchedCut, "trigger"]
+            self.h_unmatched.Fill(events[0, 'runNum'], len(unmatched))
+            self.h_total.Fill(events[0, 'runNum'], len(events))
+            thisbin = self.h_startTimes.FindBin(events[0, 'runNum'])
+            self.h_startTimes.SetBinContent(thisbin, events[0, 'startTime'])
+            
+            fileNum = events[0, 'eventNum']/1000 + 1
+            
+            #ToDo sometimes the first event has no start time, need to check a few other events 
+            self.runInfos['startTime'].loc[(self.runInfos['run'] == events[0, 'runNum']) & (self.runInfos['file'] == fileNum)] = events[0, 'startTime']
+            
+            self.runInfos['totalEvents'].loc[(self.runInfos['run'] == events[0, 'runNum']) & (self.runInfos['file'] == fileNum)] += len(events)
+            self.runInfos['unmatchedEvents'].loc[(self.runInfos['run'] == events[0, 'runNum']) & (self.runInfos['file'] == fileNum)] += len(unmatched)
+    
+    def getOfflineInfo(self):
+        #add loc statement to only get those that haven't been updated yet
+        rawFiles = self.runInfos[['run', 'file']].loc[self.runInfos['offlineFile'] == None].to_numpy()
+        for pair in rawFiles:
+            offlineFile = 'MilliQan_Run{0}.{1}_v33_firstPedestals.root'.format(pair[0], pair[1])
+            if os.path.exists(self.offlineDir+'/'+offlineFile): 
+                self.runInfos['offlineFile'].loc[(self.runInfos['run'] == pair[0]) & (self.runInfos['file'] == pair[1])] = offlineFile
+                self.runInfos['offlineDir'].loc[(self.runInfos['run'] == pair[0]) & (self.runInfos['file'] == pair[1])] = self.offlineDir
+                self.runInfos['offlineCTime'].loc[(self.runInfos['run'] == pair[0]) & (self.runInfos['file'] == pair[1])] = datetime.fromtimestamp(os.path.getctime(self.offlineDir+'/'+offlineFile))
+
+    def getRawInfo(self, directory):
+        #for directory in rawDirectories:
+        #    for sub in rawSubDirectories:
+        fullPath = self.rawDir+directory
+        if not os.path.isdir(fullPath): 
+            print("Directory {0} does not exist, skipping...".format(fullPath))
+            return
+        for ifile, filename in enumerate(os.listdir(fullPath)):
+            if not filename.endswith('.root'): continue
+            if not filename.startswith('MilliQan'): continue
+            if self.debug and len(self.runInfos) > 10: break
+
+            thisRun = runInfo()
+            runNum, fileNum = self.getRunFile(filename)
+            thisRun.run = int(runNum)
+            thisRun.file = int(fileNum)
+            thisRun.daqFile = filename
+            thisRun.rawDir = fullPath
+            thisRun.daqCTime = datetime.fromtimestamp(os.path.getctime(fullPath+'/'+filename))
+            trigName = "TriggerBoard_Run{0}.{1}.root".format(runNum, fileNum)
+            matchName = "MatchedEvents_Run{0}.{1}_rematch.root".format(runNum, fileNum)
+            if os.path.exists(fullPath+'/'+trigName): 
+                thisRun.trigFile = trigName
+                thisRun.trigCTime = datetime.fromtimestamp(os.path.getctime(fullPath+'/'+trigName))
+            if os.path.exists(fullPath+'/'+matchName): 
+                thisRun.matchFile = matchName
+                thisRun.matchCTime = datetime.fromtimestamp(os.path.getctime(fullPath+'/'+matchName))
+
+            self.runInfos.loc[len(self.runInfos.index)] = thisRun.__dict__
+                            
+    def runCheckMatchedFiles(self):
+        runs = self.runInfos.run.unique()
+        for run in runs:
+            runList = self.runInfos[['rawDir', 'matchFile']].loc[(self.runInfos['run']==run) & (self.runInfos['totalEvents']==-1)].apply(lambda x: '/'.join((x.rawDir, x.matchFile)) if (x.rawDir!=None and x.matchFile!=None) else None, axis=1).values.tolist()
+            #print(runList)
+            runList = [x+':matchedTrigEvents' for x in runList if x!=None]
+            if len(runList) == 0: continue
+            self.checkMatchedFiles(runList)
+        
+    def runCheckOfflineFiles(self):
+        #now look at offline files post processing info
+        runs = self.runInfos.run.unique()
+        for run in runs:
+            runList = self.runInfos[['offlineDir', 'offlineFile']].loc[self.runInfos['run']==run & (self.runInfos['unmatchedBoards']==-1)].apply('/'.join, axis=1).tolist()
+            runList = [x+':t' for x in runList]
+            if len(runList) == 0: continue
+            self.checkOfflineFiles(runList)
+    
+    #function to do all tasks once per directory and update json
+    def looper(self, dirs=[], subDirs=[], jsonName='checkMatching.json'):
+        if len(dirs)==0 and len(subDirs)==0:
+            dirs = self.rawDirs
+            subDirs = self.subRawDirs
+        for d1 in dirs:
+            for d2 in subDirs:
+                print("Running over directory {0}/{1}".format(d1, d2))
+                self.getRawInfo('{0}/{1}'.format(d1, d2))
+                self.getOfflineInfo()
+                self.runCheckMatchedFiles()
+                self.runCheckOfflineFiles()
+                self.saveJson(jsonName)
+            
+    def customStyle(self, s):
+        colors = ['background-color: white']*len(s)
+        if s.unmatchedEvents > 10:
+            color = 'yellow'
+            if s.unmatchedEvents > 100: color = 'red'
+            colors[s.keys().get_loc('unmatchedEvents')] = 'background-color: %s' % color
+        if s.unmatchedBoards > 5:
+            color = 'yellow'
+            if s.unmatchedBoards > 50: color = 'red'
+            colors[s.keys().get_loc('unmatchedBoards')] = 'background-color: %s' % color
+        if s.startTime == -1:
+            colors[s.keys().get_loc('startTime')] = 'background-color: red'    
+        if s.trigFile == '':
+            colors[s.keys().get_loc('trigFile')] = 'background-color: red'
+        if s.matchFile == '':
+            colors[s.keys().get_loc('matchFile')] = 'background-color: red'
+        if s.offlineFile == '':
+            colors[s.keys().get_loc('offlineFile')] = 'background-color: red'
+
+        return colors
+
+    def printInfo(self):
+        display(self.runInfos.style.apply(self.customStyle, axis=1))
+        
+if __name__ == "__main__":
+    
+    myfileChecker = fileChecker()
+    myfileChecker.debug = False
+    
+    myfileChecker.looper()
+
+    myfileChecker.printInfo()
+

--- a/Run3Detector/analysis/utilities/exampleProcessor.ipynb
+++ b/Run3Detector/analysis/utilities/exampleProcessor.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning in <TInterpreter::ReadRootmapFile>: class  edm::Wrapper<std::vector<bool> > found in libDataFormatsWrappedStdDictionaries.so  is already in libOSUT3AnalysisAnaTools.so \n",
+      "Warning in <TInterpreter::ReadRootmapFile>: class  edm::Wrapper<vector<bool> > found in libDataFormatsWrappedStdDictionaries.so  is already in libOSUT3AnalysisAnaTools.so \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Welcome to JupyROOT 6.24/07\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ROOT as r\n",
+    "import uproot\n",
+    "import hist\n",
+    "import matplotlib.pyplot as plt\n",
+    "import awkward as ak\n",
+    "import numpy as np\n",
+    "import array as arr\n",
+    "from milliqanProcessor import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def getMaxPulseTime(events):\n",
+    "    t_0 = events.time_module_calibrated[(events.eventCuts) & (events.layer0) & (events.straightPulses)]\n",
+    "    t_1 = events.time_module_calibrated[(events.eventCuts) & (events.layer1) & (events.straightPulses)]\n",
+    "    t_2 = events.time_module_calibrated[(events.eventCuts) & (events.layer2) & (events.straightPulses)]\n",
+    "    t_3 = events.time_module_calibrated[(events.eventCuts) & (events.layer3) & (events.straightPulses)]\n",
+    "\n",
+    "    #example of getting max value mask\n",
+    "    events['max_height'] = events.height == ak.max(events.height, axis=1, keepdims=True)\n",
+    "\n",
+    "    passingHeights0 = events.height[(events.eventCuts) & (events.layer0) & (events.straightPulses)]\n",
+    "    passingHeights1 = events.height[(events.eventCuts) & (events.layer1) & (events.straightPulses)]\n",
+    "    passingHeights2 = events.height[(events.eventCuts) & (events.layer2) & (events.straightPulses)]\n",
+    "    passingHeights3 = events.height[(events.eventCuts) & (events.layer3) & (events.straightPulses)]\n",
+    "\n",
+    "    #print(len(ak.drop_none(ak.flatten(ak.max(passingHeights0, axis=1, keepdims=True)))), len(ak.drop_none(ak.flatten(ak.max(passingHeights1, axis=1, keepdims=True)))), len(ak.drop_none(ak.flatten(ak.max(passingHeights2, axis=1, keepdims=True)))), len(ak.drop_none(ak.flatten(ak.max(passingHeights3, axis=1, keepdims=True)))))\n",
+    "\n",
+    "    max_pulse0 = ak.pad_none(passingHeights0, 1, axis=1) == ak.max(passingHeights0, axis=1, keepdims=True, initial=0)\n",
+    "    max_pulse1 = ak.pad_none(passingHeights1, 1, axis=1) == ak.max(passingHeights1, axis=1, keepdims=True, initial=0)\n",
+    "    max_pulse2 = ak.pad_none(passingHeights2, 1, axis=1) == ak.max(passingHeights2, axis=1, keepdims=True, initial=0)\n",
+    "    max_pulse3 = ak.pad_none(passingHeights3, 1, axis=1) == ak.max(passingHeights3, axis=1, keepdims=True, initial=0)\n",
+    "\n",
+    "    #print(ak.pad_none(passingHeights0, 1, axis=1))\n",
+    "    #print(ak.max(passingHeights0, axis=1, keepdims=True, initial=0))\n",
+    "\n",
+    "    #print(ak.drop_none(max_pulse0, axis=1))\n",
+    "\n",
+    "    t_0 = t_0[ak.drop_none(max_pulse0, axis=1)]\n",
+    "    t_1 = t_1[ak.drop_none(max_pulse1, axis=1)]\n",
+    "    t_2 = t_2[ak.drop_none(max_pulse2, axis=1)]\n",
+    "    t_3 = t_3[ak.drop_none(max_pulse3, axis=1)]\n",
+    "\n",
+    "    return t_0, t_1, t_2, t_3\n",
+    "\n",
+    "    #np.set_printoptions(threshold=np.inf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of events 404605\n",
+      "Number of passing events 111616\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning in <TROOT::Append>: Replacing existing TH1: h_timeDiff (Potential memory leak).\n",
+      "Warning in <TROOT::Append>: Replacing existing TH1: h_time0 (Potential memory leak).\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAD8CAYAAABpcuN4AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAWMklEQVR4nO3dcbBedX3n8fdHooxmtMDmWoWEAt0UBxQjPhNtRzC0UwwsmO6ys4XJCBZmU7ay+0c7pdKsZEbGPxz+6Kyt1UY3Mu6EsDt107qslKSzo+xos3qDIYQOYkAoSdlJNA5YcWgj3/3jd8vJQ3JPbu59cp+b7fs1c+ae8z3n/J7vc/JcPpznnOe5qSqQJGkar2HcHUiSFjSDQpLUy6CQJPUyKCRJvQwKSVIvg0KS1GtGQZFkU5IDSfZw9LrfSVJJltCWk+RTSfYm2Z3kUrptb0ry3bTpJkb2NCRJJ8tMzyjuAVbzqmKSZcCVwN/Qla8CltOmdcBnaNueBWwA3gOsBDYkOZPZdi5JmhczCoqqegg4xNGr/gC4HagjPrW3BvhiVVVV7QDOSPJW4APA9qo6VFU/BLbD0eEjSVpYFjHLHZOsAfZX1SNJOGLVOcCzdMv7aLXp6scaex2wDmDx4sXvftvb3sYs25Skf5J27tz5/aqaYARjzSookrwB+H3gSkbQxKtV1UZgI8BgMKjJyUlOwsNI0v+3kjzDiMaa7V1PPw+cDzyS5GlgKfBwkrcA+4FldNsupdWmq0uSFrBZBUVVPVpVb66q86rqPGAfcGlV/V/gy8CNaXc/vRd4vqqeAx4ErkxyZtpF7CtpNUnSAjbT22O3AH8FXJhkX5JbmH7zrwBPAXuBzwG/BVBVh4C7gG/Rpo9Xq0mSFrAs9K8Z9xqFJJ24JDurasAIxvKT2ZKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReBoUkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSp13GDIsmmJAeS7KGr3ZVkd5JdSbYlOZtW/9202q4ke5L8NMlZtHVPJ3k0bd2kf9tUkk4NMzmjuAdYzXDt7qq6pKpWAPcDdwJU1d1VtaJa/Q7ga1V1iG6/K6qtH8nfcZUknXzHDYqqegg4xHDtBbrFxUBx9K43AFuYS3eSpLGb9TWKJJ9I8iywFtoZxRHr3gCsBr5EVy5gW5KdSdYxy8eVJM2vWQdFVa2vqmXAZuA2hldfC3y9ht92el9VXQpcBXwkyeVMM3aSdUkmk0wePHiQWbYoSRqBUdz1tBm4juHa9TD8tlNV7af9PABsBVYyzYBVtbGqBlU1mJiYYO4tSpJma1ZBkWQ53eIa4HG6dT8DvB/4c7ra4iRvZGoeuBLYA5KkhW4Rx9kgyRZgFbAkyT5gA3B1kguBl4FngFvpdvmXwLaq+jFd7WeBrUmYesx7q+ovGMlTkCSdTKmqY9ywtHAMBoOanJz0YxeSdAKS7KwRfRTBT2ZLknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReBoUkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSp14yCIsmmJAeS7KGr3ZVkd5JdSbYlOZtWX5Xk+bT6riR30u2zOsl3kuxN8lFG/nQkSaM20zOKe4DVDNfurqpLqmoFcD9wJ926/11VK6pNHwdIchrwaeAq4CLghiQXMaf2JUkn24yCoqoeAg4xXHuBbnExUPQPsxLYW1VPVdXfA/cBa5h5r5KkMZjTNYokn0jyLLAWhs4ofjHJI0keSHIxrXYO8CzdNvtotWONuy7JZJLJgwcPMocWJUlzNKegqKr1VbUM2AzcRis/DPxcVb0T+EPgzzjxcTdW1aCqBhMTE8yhRUnSHI3qrqfNwHUAVfVCVf0dbf4rwGuTLAH2A8vo9llKq0mSFrBZB0WS5XSLa4DHafW3JAltfiXtMX4AfAtYnuT8JK8Drge+zCwfX5I0PxYxg42SbAFWAUuS7AM2AFcnuRB4GXgGuJW2+b8G/l2Sw8BPgOurqoDDSW4DHgROAzZV1WOM8tlIkkYuVXWcm5XGazAY1OTkJOPuQ5JOJUl2VtWAEYzlJ7MlSb0MCklSL4NCktTLoJAk9TIoJEm9DApJUi+DQpLUy6CQJPUyKCRJvQwKSVIvg0KS1MugkCT1MigkSb0MCklSL4NCktTLoJAk9TIoJEm9DApJUq/jBkWSTUkOJNlDV7srye4ku5JsS3I2rb42rf5okm8keSfdPk+n1XclmfRvm0rSqWEmZxT3AKsZrt1dVZdU1QrgfuBOWv17wPur6h3AXcBGhve7oqpW1Ij+jqsk6eRbxHE2qKqHkpzHcO0FusXFQNHq36Cr7wCWMoImJUnjc9ygmE6STwA3As8DV3D0JrcAD9AtF7AtSQF/UlUbOXqffxx7HbAO4Nxzz2WWLUqSRmDWF7Oran1VLQM2A7dxxLokVwC3AL9HV35fVV0KXAV8JMnlTD/2xqoaVNVgYmKCWbYoSRqBUdz1tBm4jqmFJJcAnwfWVNUPmKpX1X7azwPAVmAlc39sSdJJNqugSLKcbnEN8Ditfi7w34EPVdUTdNsvTvJGpuaBK4E9IEla6I57jSLJFmAVsCTJPmADcHWSC4GXgWeAW2mb3wn8M+CPkwAcrnaH088CW9Nqi4B7q+ovGO1zkSSdBKkqxt1En8FgUJOTk37sQpJOQJKdNaKPIvjJbElSL4NCktTLoJAk9TIoJEm9DApJUi+DQpLUy6CQJPUyKCRJvQwKSVIvg0KS1MugkCT1MigkSb0MCklSL4NCktTLoJAk9TIoJEm9DApJUi+DQpLUa0ZBkWRTkgNJ9tDV7kqyO8muJNuSnE2rJ8mnkuxNW38p3T43Jflu2nQTI386kqRRm+kZxT3AaoZrd1fVJVW1ArgfuJNWvwpYTpvWAZ8BSHIWsAF4D7AS2JDkTObUviTpZJtRUFTVQ8Ahhmsv0C0uBoo2vwb4YlVVVe0AzkjyVuADwPaqOlRVPwS2w1HhI0laYBYxh52TfAK4EXgeuIJWPgd4lm6zfbTadPVjjbsOWAdw7rnnMocWJUlzNKeL2VW1vqqWAZuB2xhJS1BVG6tqUFWDiYkJRjSsJGkWRnXX02bgOtr8fmAZ3bqltNp0dUnSAjbroEiynG5xDfA4bf7LwI1pdz+9F3i+qp4DHgSuTHJm2kXsK2k1SdICNqNrFEm2AKuAJUn2ARuAq5NcCLwMPAPcStv8K8DVwF7gReA3AKrqUJK7gG/Rtvt4VR068gK5JGnhSVUx7ib6DAaDmpycZNx9SNKpJMnOqhowgrH8ZLYkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReBoUkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6nXcoEiyKcmBJHvoancneTzJ7iRbk5xBq69Nsivd9HKSFbR1X03ynXTr3sxJe1qSpFGZyRnFPcBqhmvbgbdX1SXAE8AdAFW1uapWVNUK4EPA96pqF91+a2tqfVUdYO79S5JOsuMGRVU9BBxiuLatqg7TFncASzl61xuA+5hrh5KksRrFNYqbgQc4uv7rwBaGa19Ie9vpY0nCNAMmWZdkMsnkwYMHmXuLkqTZmlNQJFkPHAY2M1x/D/BiVe2hK6+tqncAl9GmDzHNuFW1saoGVTWYmJhgDi1KkuZo1kGR5MPANcDaqiqGV18Pw2cTVbWf9vNHwL3ASmb52JKk+bOIWeyUZDVwO/D+qnqR4XWvAf4NcBldbRFwRlV9P8lrgWuAv2S2XUuS5s1xgyLJFmAVsCTJPmADcAdwOrA97VLDjqq6lbbL5cCzVfUU3TCnAw+mhcRpwF8Cn2NUz0KSdNIcNyiq6gaOLv9npt/+q8B7Ga79GHg3J9qdJGns/GS2JKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReBoUkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSep13KBIsinJgSR76Gp3J3k8ye4kW5OcQaufl+QnSXalTZ+l2+fdSR5NsjfJp5L2x7YlSQvbTM4o7gFWM1zbDry9qi4BngDuoFv3ZFWtqDbdSlf/DPBvgeW06dVjSpIWoOMGRVU9BBxiuLatqg7TFncAS+kZI8lbgTdV1Y6qKuCLwK8xq5YlSfNpFNcobgYeoFs+P8m3k3wtyWW02jnAPrpt9tFqx5RkXZLJJJMHDx5k7i1KkmZrTkGRZD1wGNhMKz0HnFtV7wJ+G7g3yZs4wXGramNVDapqMDExwRxalCTN0SJmuWOSDwPXAL9S7e0kquol4CXa/M4kTwK/AOyHobenltJqkqQFblZnFElWA7cDH6yqF+nqE0lOo81fACwHnqqq54AXkrw37W6nG4E/Z67dS5JOuuOeUSTZAqwCliTZB2wA7gBOB7an3eW6o9odTpcDH0/yD8DLwK1VdWjqQvhvAfcArwcegKHrGpKkBSrV3jVasAaDQU1OTjLuPiTpVJJkZ1UNGMFYfjJbktTLoJAk9TIoJEm9DApJUi+DQpLUy6CQJPUyKCRJvQwKSVIvg0KS1MugkCT1MigkSb0MCklSL4NCktTLoJAk9TIoJEm9DApJUi+DQpLUy6CQJPU6blAk2ZTkQJI9dLW7kzyeZHeSrUnOoNV/NcnOJI+m/fxlun2+muQ7SXalTW/mpDwlSdIozeSM4h5gNcO17cDbq+oS4AngDlr9+8C1VfUO4CbgvzC839qqWlFtOsDs+5YkzZPjBkVVPQQcYri2raoO0xZ3AEtp9W9X1d/S6o8Br09yOqPrV5I0z0ZxjeJm4AGOrl8HPFxVL9HVvpD2ttPHkoS5P7Yk6SSbU1AkWQ8cBjYzXL8Y+CTwm3TltdXekrqMNn2I6cddl2QyyeTBgweZQ4uSpDmadVAk+TBwDbC2qoquvhTYCtxYVU8yVa+q/bSfPwLuBVYyzdhVtbGqBlU1mJiYYJYtSpJGYFZBkWQ1cDvwwap6ka5+BvA/gY9W1dfp6ouSLKHNvxa4BtgDkqSFbia3x24B/gq4MMm+JLcAfwS8Edieds3hs7TNbwP+OXBnhm+DPR14MMluYBewH/gco38+kqQRS3XvGi1Ig8GgJicnGXcfknQqSbKzqgaMYCw/mS1J6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReBoUkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReMwqKJJuSHEiyh652d5LHk+xOsjXJGXTr7kiyN8l3knyArr46rbY3yUcZ6VORJJ0MMz2juAdYzXBtO/D2qroEeAK4AyDJRcD1wMW0ff44yWlJTgM+DVwFXATckLatJGkBm1FQVNVDwCGGa9uq6jBtcQewlDa/Brivql6qqu8Be4GVtGlvVT1VVX8P3EfbVpK0gC1iNOPcDPxX2vw5wA66dftoNYBnGa6/h2MMlmQdsI62+FKOeMtrAVsCfJ9xd9HvVOgRsM8Rs8/ROlX6vJARDTTnoEiyHjgMbGbO7TRVtRHYSBt/sqoGjGjsk+VU6PNU6BGwzxGzz9HKKdQnIxprTkGR5MPANcCvVFXRyvuBZXSbLaXVYPq6JGmBmvXtsUlWA7cDH6yqF+lWfRm4PsnpSc4HlgPfBL4FLE9yfpLXAdfTtpUkLWAzOqNIsgVYBSxJsg/YANwBnA5sTwKwo6purarHkvw34K+Bw8BHquqntHFuAx4ETgM2VdVjHP/hN3Jiz2lcToU+T4UeAfscMfscrX9yfaZeecdIkqSj+clsSVIvg0KS1Gveg+JU+TqQE+kzya8m2Znk0bSfv0y3z1fT+tyVNr2Z8fV5XpKfpOvls3T7vDut/71JPpW0C09j6nNtuh53JXk5yQraunEcz7vSetyVZFuSs2n1pB2rvWnrL6Xb56Yk302bbmJ8Pa5Nqz+a5BtJ3km3z9Np9V0Z4a2Us+xzVZLn0/273km3zzh+16fr83fT9bgnyU+TnEVbN+/H84h1v5OkkiyhLY/2tVlVzOcEXA5cCuyprnYlsKja/CeBT1abvwh4BDgdOB94EjiNNj0JXAC8jrbNRTW+Pt8FnF1t/u3A/ur2+SowqIVxPM/jiO1eNc43gfcCAR4Arqox9fmq/d4BPFnjPZ5vqm7+PwCfrTZ/Ne1YhXbs/k+1+lnAU7SfZ9Lmz6zx9PhLTD02cBVTPU5t9zSwpBbGsVwF3F9HjzGu3/Vj9lnD+10L/K8a4/Gcqi8DHgSeYerxYbSvzXk/o6g6Nb4O5ET6rKpvV9Xf0uqPAa9Pcjoj7GcUfU4nyVuBN1XVjqoq4IvAr7Ew+rwBuI8R9tJnmj5foFtcDNTUHSBrgC9WVVXVDuCMtGP5AWB7VR2qqh8C2+Go70qblx6r6hvVegCO/1oYpRM8ltMZ1+/6TPq8AdjCCHvpc6w+p/wBcDsM9TjS1+ZCvEZxM/AAbf4cOOprP85h+vp8OrLPI10HPFxVL9HVvpB2OvqxjPgtnRl4dZ/nJ/l2kq8luYxWOwfYR7fNQjqevw5H/TLO+/FM8okkzwJrgTun3hZZUK/PaXo80i0wdIwL2JZkZ5J1nOT+/lFPn7+Y5JEkDyS5mFYb2+963/FM8gZgNfAluvK8H88ka4D9VfUIw6tG+tpcUEFxMr4O5GSYrs+0F/cngd+kK6+tqncAl9GmDzG+Pp8Dzq2qdwG/Ddyb5E3MUz/T6Tme7wFerKo9R7wnO5bjWVXrq2oZrcfbmIfHPFF9PSa5ArgF+D268vuq6lLgKuAjSS5nfH0+DPxcVb0T+EPgz5iHXvoc59/8WuDrVXXoiP/Dn9fjmRZWvw/H/J+CkVowQXHE14Gsrfb2BzDt14H0fU3IOPokyVJgK3BjVT3JVL2q9tN+/gi4F1jJmPqs9hbeD2jzO4EngV8A9sPQWxJjP55Trofhs4lxHc8jbAauo80vuNfnlCN7JMklwOeBNTX17w8ceSwPAFthfMeyql6oqr+jzX8FeG3ahdlxH8uhPo/Q99qcr+P588D5wCNJngaWAg8neQuM+LV5Mi66zOCizNBFVWA18NfARA1vdzEMXcx+CjgNWESbPx9eucB1cY2vzzNoPfyrGq4vglcuLr0W+FPg1hpfnxPAadXmLwD2A2dVW371xeyra0x9Tq17Da2/C2r8x3N5dfP/HvjTavP/AoYuGH6zWv0s4HvAmbTpe0wd5zH0eC6wF/ilGt5/MfDG6ua/Aayu8R3Lt8ArHwBeCfwN7biO63f9mH1WW/4Z4BCwuMZ8PF+17pWL6TDa1+a8BwWwBXgO+AdgH3ALsBd4FthFm165wwBYDzwJfAe6O3GAq4EnaOvW1xj7BP4j8GO6+i7gzcBiYCewG3gM+E/Q/kM9pj6vo/WxC3gYuLa6cQbAHtrx/CNov7Rj/HdfBeyo4THGdTy/RDs2u4H/AZxTbdsAn6Yds0ehuxsLuJn2/PYCv1Hj6/HzwA/pjvFktfoFwCO06TGYt9+h6fq8jdbHI8AO6IINxvK7fsw+q23/YeC+Gh5jLMezhtcfGRQjfW36FR6SpF4L5hqFJGlhMigkSb0MCklSL4NCktTLoJAk9TIoJEm9DApJUq//Bz/ujTZcvJsqAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "\n",
+    "    filelist = ['/store/user/milliqan/trees/v33/combined/MilliQan_Run1031_combined.root:t']\n",
+    "    branches = ['boardsMatched', 'time_module_calibrated', 'height', 'area', 'column', 'row', 'layer']\n",
+    "\n",
+    "    branchesToMake = ['layerCut', 'fourLayerCut', 'straightLineCut', \"combineCuts(['fourLayers', 'straightPath']; 'eventCuts')\", 'threeAreaSaturatedInLine(50000)', \"combineCuts(['eventCuts', 'three_sat']; 'eventCuts')\"]\n",
+    "\n",
+    "    myiterator = milliqanProcessor(filelist, branches)\n",
+    "    myiterator.setCustomFunction(getMaxPulseTime)\n",
+    "    myiterator.setBranches(branchesToMake)\n",
+    "    myiterator.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c1 = r.TCanvas(\"c1\", \"c1\", 600, 600)\n",
+    "c1.cd()\n",
+    "myiterator.h_timeDiff.Draw()\n",
+    "c1.Draw()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Run3Detector/analysis/utilities/exampleProcessor.ipynb
+++ b/Run3Detector/analysis/utilities/exampleProcessor.ipynb
@@ -2,25 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning in <TInterpreter::ReadRootmapFile>: class  edm::Wrapper<std::vector<bool> > found in libDataFormatsWrappedStdDictionaries.so  is already in libOSUT3AnalysisAnaTools.so \n",
-      "Warning in <TInterpreter::ReadRootmapFile>: class  edm::Wrapper<vector<bool> > found in libDataFormatsWrappedStdDictionaries.so  is already in libOSUT3AnalysisAnaTools.so \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Welcome to JupyROOT 6.24/07\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import ROOT as r\n",
     "import uproot\n",
@@ -34,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,38 +60,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of events 404605\n",
-      "Number of passing events 111616\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning in <TROOT::Append>: Replacing existing TH1: h_timeDiff (Potential memory leak).\n",
-      "Warning in <TROOT::Append>: Replacing existing TH1: h_time0 (Potential memory leak).\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAD8CAYAAABpcuN4AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAWMklEQVR4nO3dcbBedX3n8fdHooxmtMDmWoWEAt0UBxQjPhNtRzC0UwwsmO6ys4XJCBZmU7ay+0c7pdKsZEbGPxz+6Kyt1UY3Mu6EsDt107qslKSzo+xos3qDIYQOYkAoSdlJNA5YcWgj3/3jd8vJQ3JPbu59cp+b7fs1c+ae8z3n/J7vc/JcPpznnOe5qSqQJGkar2HcHUiSFjSDQpLUy6CQJPUyKCRJvQwKSVIvg0KS1GtGQZFkU5IDSfZw9LrfSVJJltCWk+RTSfYm2Z3kUrptb0ry3bTpJkb2NCRJJ8tMzyjuAVbzqmKSZcCVwN/Qla8CltOmdcBnaNueBWwA3gOsBDYkOZPZdi5JmhczCoqqegg4xNGr/gC4HagjPrW3BvhiVVVV7QDOSPJW4APA9qo6VFU/BLbD0eEjSVpYFjHLHZOsAfZX1SNJOGLVOcCzdMv7aLXp6scaex2wDmDx4sXvftvb3sYs25Skf5J27tz5/aqaYARjzSookrwB+H3gSkbQxKtV1UZgI8BgMKjJyUlOwsNI0v+3kjzDiMaa7V1PPw+cDzyS5GlgKfBwkrcA+4FldNsupdWmq0uSFrBZBUVVPVpVb66q86rqPGAfcGlV/V/gy8CNaXc/vRd4vqqeAx4ErkxyZtpF7CtpNUnSAjbT22O3AH8FXJhkX5JbmH7zrwBPAXuBzwG/BVBVh4C7gG/Rpo9Xq0mSFrAs9K8Z9xqFJJ24JDurasAIxvKT2ZKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReBoUkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSp13GDIsmmJAeS7KGr3ZVkd5JdSbYlOZtW/9202q4ke5L8NMlZtHVPJ3k0bd2kf9tUkk4NMzmjuAdYzXDt7qq6pKpWAPcDdwJU1d1VtaJa/Q7ga1V1iG6/K6qtH8nfcZUknXzHDYqqegg4xHDtBbrFxUBx9K43AFuYS3eSpLGb9TWKJJ9I8iywFtoZxRHr3gCsBr5EVy5gW5KdSdYxy8eVJM2vWQdFVa2vqmXAZuA2hldfC3y9ht92el9VXQpcBXwkyeVMM3aSdUkmk0wePHiQWbYoSRqBUdz1tBm4juHa9TD8tlNV7af9PABsBVYyzYBVtbGqBlU1mJiYYO4tSpJma1ZBkWQ53eIa4HG6dT8DvB/4c7ra4iRvZGoeuBLYA5KkhW4Rx9kgyRZgFbAkyT5gA3B1kguBl4FngFvpdvmXwLaq+jFd7WeBrUmYesx7q+ovGMlTkCSdTKmqY9ywtHAMBoOanJz0YxeSdAKS7KwRfRTBT2ZLknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReBoUkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSp14yCIsmmJAeS7KGr3ZVkd5JdSbYlOZtWX5Xk+bT6riR30u2zOsl3kuxN8lFG/nQkSaM20zOKe4DVDNfurqpLqmoFcD9wJ926/11VK6pNHwdIchrwaeAq4CLghiQXMaf2JUkn24yCoqoeAg4xXHuBbnExUPQPsxLYW1VPVdXfA/cBa5h5r5KkMZjTNYokn0jyLLAWhs4ofjHJI0keSHIxrXYO8CzdNvtotWONuy7JZJLJgwcPMocWJUlzNKegqKr1VbUM2AzcRis/DPxcVb0T+EPgzzjxcTdW1aCqBhMTE8yhRUnSHI3qrqfNwHUAVfVCVf0dbf4rwGuTLAH2A8vo9llKq0mSFrBZB0WS5XSLa4DHafW3JAltfiXtMX4AfAtYnuT8JK8Drge+zCwfX5I0PxYxg42SbAFWAUuS7AM2AFcnuRB4GXgGuJW2+b8G/l2Sw8BPgOurqoDDSW4DHgROAzZV1WOM8tlIkkYuVXWcm5XGazAY1OTkJOPuQ5JOJUl2VtWAEYzlJ7MlSb0MCklSL4NCktTLoJAk9TIoJEm9DApJUi+DQpLUy6CQJPUyKCRJvQwKSVIvg0KS1MugkCT1MigkSb0MCklSL4NCktTLoJAk9TIoJEm9DApJUq/jBkWSTUkOJNlDV7srye4ku5JsS3I2rb42rf5okm8keSfdPk+n1XclmfRvm0rSqWEmZxT3AKsZrt1dVZdU1QrgfuBOWv17wPur6h3AXcBGhve7oqpW1Ij+jqsk6eRbxHE2qKqHkpzHcO0FusXFQNHq36Cr7wCWMoImJUnjc9ygmE6STwA3As8DV3D0JrcAD9AtF7AtSQF/UlUbOXqffxx7HbAO4Nxzz2WWLUqSRmDWF7Oran1VLQM2A7dxxLokVwC3AL9HV35fVV0KXAV8JMnlTD/2xqoaVNVgYmKCWbYoSRqBUdz1tBm4jqmFJJcAnwfWVNUPmKpX1X7azwPAVmAlc39sSdJJNqugSLKcbnEN8Ditfi7w34EPVdUTdNsvTvJGpuaBK4E9IEla6I57jSLJFmAVsCTJPmADcHWSC4GXgWeAW2mb3wn8M+CPkwAcrnaH088CW9Nqi4B7q+ovGO1zkSSdBKkqxt1En8FgUJOTk37sQpJOQJKdNaKPIvjJbElSL4NCktTLoJAk9TIoJEm9DApJUi+DQpLUy6CQJPUyKCRJvQwKSVIvg0KS1MugkCT1MigkSb0MCklSL4NCktTLoJAk9TIoJEm9DApJUi+DQpLUa0ZBkWRTkgNJ9tDV7kqyO8muJNuSnE2rJ8mnkuxNW38p3T43Jflu2nQTI386kqRRm+kZxT3AaoZrd1fVJVW1ArgfuJNWvwpYTpvWAZ8BSHIWsAF4D7AS2JDkTObUviTpZJtRUFTVQ8Ahhmsv0C0uBoo2vwb4YlVVVe0AzkjyVuADwPaqOlRVPwS2w1HhI0laYBYxh52TfAK4EXgeuIJWPgd4lm6zfbTadPVjjbsOWAdw7rnnMocWJUlzNKeL2VW1vqqWAZuB2xhJS1BVG6tqUFWDiYkJRjSsJGkWRnXX02bgOtr8fmAZ3bqltNp0dUnSAjbroEiynG5xDfA4bf7LwI1pdz+9F3i+qp4DHgSuTHJm2kXsK2k1SdICNqNrFEm2AKuAJUn2ARuAq5NcCLwMPAPcStv8K8DVwF7gReA3AKrqUJK7gG/Rtvt4VR068gK5JGnhSVUx7ib6DAaDmpycZNx9SNKpJMnOqhowgrH8ZLYkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReBoUkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6nXcoEiyKcmBJHvoancneTzJ7iRbk5xBq69Nsivd9HKSFbR1X03ynXTr3sxJe1qSpFGZyRnFPcBqhmvbgbdX1SXAE8AdAFW1uapWVNUK4EPA96pqF91+a2tqfVUdYO79S5JOsuMGRVU9BBxiuLatqg7TFncASzl61xuA+5hrh5KksRrFNYqbgQc4uv7rwBaGa19Ie9vpY0nCNAMmWZdkMsnkwYMHmXuLkqTZmlNQJFkPHAY2M1x/D/BiVe2hK6+tqncAl9GmDzHNuFW1saoGVTWYmJhgDi1KkuZo1kGR5MPANcDaqiqGV18Pw2cTVbWf9vNHwL3ASmb52JKk+bOIWeyUZDVwO/D+qnqR4XWvAf4NcBldbRFwRlV9P8lrgWuAv2S2XUuS5s1xgyLJFmAVsCTJPmADcAdwOrA97VLDjqq6lbbL5cCzVfUU3TCnAw+mhcRpwF8Cn2NUz0KSdNIcNyiq6gaOLv9npt/+q8B7Ga79GHg3J9qdJGns/GS2JKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReBoUkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSep13KBIsinJgSR76Gp3J3k8ye4kW5OcQaufl+QnSXalTZ+l2+fdSR5NsjfJp5L2x7YlSQvbTM4o7gFWM1zbDry9qi4BngDuoFv3ZFWtqDbdSlf/DPBvgeW06dVjSpIWoOMGRVU9BBxiuLatqg7TFncAS+kZI8lbgTdV1Y6qKuCLwK8xq5YlSfNpFNcobgYeoFs+P8m3k3wtyWW02jnAPrpt9tFqx5RkXZLJJJMHDx5k7i1KkmZrTkGRZD1wGNhMKz0HnFtV7wJ+G7g3yZs4wXGramNVDapqMDExwRxalCTN0SJmuWOSDwPXAL9S7e0kquol4CXa/M4kTwK/AOyHobenltJqkqQFblZnFElWA7cDH6yqF+nqE0lOo81fACwHnqqq54AXkrw37W6nG4E/Z67dS5JOuuOeUSTZAqwCliTZB2wA7gBOB7an3eW6o9odTpcDH0/yD8DLwK1VdWjqQvhvAfcArwcegKHrGpKkBSrV3jVasAaDQU1OTjLuPiTpVJJkZ1UNGMFYfjJbktTLoJAk9TIoJEm9DApJUi+DQpLUy6CQJPUyKCRJvQwKSVIvg0KS1MugkCT1MigkSb0MCklSL4NCktTLoJAk9TIoJEm9DApJUi+DQpLUy6CQJPU6blAk2ZTkQJI9dLW7kzyeZHeSrUnOoNV/NcnOJI+m/fxlun2+muQ7SXalTW/mpDwlSdIozeSM4h5gNcO17cDbq+oS4AngDlr9+8C1VfUO4CbgvzC839qqWlFtOsDs+5YkzZPjBkVVPQQcYri2raoO0xZ3AEtp9W9X1d/S6o8Br09yOqPrV5I0z0ZxjeJm4AGOrl8HPFxVL9HVvpD2ttPHkoS5P7Yk6SSbU1AkWQ8cBjYzXL8Y+CTwm3TltdXekrqMNn2I6cddl2QyyeTBgweZQ4uSpDmadVAk+TBwDbC2qoquvhTYCtxYVU8yVa+q/bSfPwLuBVYyzdhVtbGqBlU1mJiYYJYtSpJGYFZBkWQ1cDvwwap6ka5+BvA/gY9W1dfp6ouSLKHNvxa4BtgDkqSFbia3x24B/gq4MMm+JLcAfwS8Edieds3hs7TNbwP+OXBnhm+DPR14MMluYBewH/gco38+kqQRS3XvGi1Ig8GgJicnGXcfknQqSbKzqgaMYCw/mS1J6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReBoUkqZdBIUnqZVBIknoZFJKkXgaFJKmXQSFJ6mVQSJJ6GRSSpF4GhSSpl0EhSeplUEiSehkUkqReMwqKJJuSHEiyh652d5LHk+xOsjXJGXTr7kiyN8l3knyArr46rbY3yUcZ6VORJJ0MMz2juAdYzXBtO/D2qroEeAK4AyDJRcD1wMW0ff44yWlJTgM+DVwFXATckLatJGkBm1FQVNVDwCGGa9uq6jBtcQewlDa/Brivql6qqu8Be4GVtGlvVT1VVX8P3EfbVpK0gC1iNOPcDPxX2vw5wA66dftoNYBnGa6/h2MMlmQdsI62+FKOeMtrAVsCfJ9xd9HvVOgRsM8Rs8/ROlX6vJARDTTnoEiyHjgMbGbO7TRVtRHYSBt/sqoGjGjsk+VU6PNU6BGwzxGzz9HKKdQnIxprTkGR5MPANcCvVFXRyvuBZXSbLaXVYPq6JGmBmvXtsUlWA7cDH6yqF+lWfRm4PsnpSc4HlgPfBL4FLE9yfpLXAdfTtpUkLWAzOqNIsgVYBSxJsg/YANwBnA5sTwKwo6purarHkvw34K+Bw8BHquqntHFuAx4ETgM2VdVjHP/hN3Jiz2lcToU+T4UeAfscMfscrX9yfaZeecdIkqSj+clsSVIvg0KS1Gveg+JU+TqQE+kzya8m2Znk0bSfv0y3z1fT+tyVNr2Z8fV5XpKfpOvls3T7vDut/71JPpW0C09j6nNtuh53JXk5yQraunEcz7vSetyVZFuSs2n1pB2rvWnrL6Xb56Yk302bbmJ8Pa5Nqz+a5BtJ3km3z9Np9V0Z4a2Us+xzVZLn0/273km3zzh+16fr83fT9bgnyU+TnEVbN+/H84h1v5OkkiyhLY/2tVlVzOcEXA5cCuyprnYlsKja/CeBT1abvwh4BDgdOB94EjiNNj0JXAC8jrbNRTW+Pt8FnF1t/u3A/ur2+SowqIVxPM/jiO1eNc43gfcCAR4Arqox9fmq/d4BPFnjPZ5vqm7+PwCfrTZ/Ne1YhXbs/k+1+lnAU7SfZ9Lmz6zx9PhLTD02cBVTPU5t9zSwpBbGsVwF3F9HjzGu3/Vj9lnD+10L/K8a4/Gcqi8DHgSeYerxYbSvzXk/o6g6Nb4O5ET6rKpvV9Xf0uqPAa9Pcjoj7GcUfU4nyVuBN1XVjqoq4IvAr7Ew+rwBuI8R9tJnmj5foFtcDNTUHSBrgC9WVVXVDuCMtGP5AWB7VR2qqh8C2+Go70qblx6r6hvVegCO/1oYpRM8ltMZ1+/6TPq8AdjCCHvpc6w+p/wBcDsM9TjS1+ZCvEZxM/AAbf4cOOprP85h+vp8OrLPI10HPFxVL9HVvpB2OvqxjPgtnRl4dZ/nJ/l2kq8luYxWOwfYR7fNQjqevw5H/TLO+/FM8okkzwJrgTun3hZZUK/PaXo80i0wdIwL2JZkZ5J1nOT+/lFPn7+Y5JEkDyS5mFYb2+963/FM8gZgNfAluvK8H88ka4D9VfUIw6tG+tpcUEFxMr4O5GSYrs+0F/cngd+kK6+tqncAl9GmDzG+Pp8Dzq2qdwG/Ddyb5E3MUz/T6Tme7wFerKo9R7wnO5bjWVXrq2oZrcfbmIfHPFF9PSa5ArgF+D268vuq6lLgKuAjSS5nfH0+DPxcVb0T+EPgz5iHXvoc59/8WuDrVXXoiP/Dn9fjmRZWvw/H/J+CkVowQXHE14Gsrfb2BzDt14H0fU3IOPokyVJgK3BjVT3JVL2q9tN+/gi4F1jJmPqs9hbeD2jzO4EngV8A9sPQWxJjP55Trofhs4lxHc8jbAauo80vuNfnlCN7JMklwOeBNTX17w8ceSwPAFthfMeyql6oqr+jzX8FeG3ahdlxH8uhPo/Q99qcr+P588D5wCNJngaWAg8neQuM+LV5Mi66zOCizNBFVWA18NfARA1vdzEMXcx+CjgNWESbPx9eucB1cY2vzzNoPfyrGq4vglcuLr0W+FPg1hpfnxPAadXmLwD2A2dVW371xeyra0x9Tq17Da2/C2r8x3N5dfP/HvjTavP/AoYuGH6zWv0s4HvAmbTpe0wd5zH0eC6wF/ilGt5/MfDG6ua/Aayu8R3Lt8ArHwBeCfwN7biO63f9mH1WW/4Z4BCwuMZ8PF+17pWL6TDa1+a8BwWwBXgO+AdgH3ALsBd4FthFm165wwBYDzwJfAe6O3GAq4EnaOvW1xj7BP4j8GO6+i7gzcBiYCewG3gM+E/Q/kM9pj6vo/WxC3gYuLa6cQbAHtrx/CNov7Rj/HdfBeyo4THGdTy/RDs2u4H/AZxTbdsAn6Yds0ehuxsLuJn2/PYCv1Hj6/HzwA/pjvFktfoFwCO06TGYt9+h6fq8jdbHI8AO6IINxvK7fsw+q23/YeC+Gh5jLMezhtcfGRQjfW36FR6SpF4L5hqFJGlhMigkSb0MCklSL4NCktTLoJAk9TIoJEm9DApJUq//Bz/ujTZcvJsqAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "if __name__ == \"__main__\":\n",
     "\n",

--- a/Run3Detector/analysis/utilities/milliqanCuts.py
+++ b/Run3Detector/analysis/utilities/milliqanCuts.py
@@ -1,0 +1,159 @@
+#!/usr/bin/python3
+
+import awkward as ak
+
+#function to allow multiple masks (cuts) to be combined together and saved as name
+def combineCuts(events, cuts, name):
+    name = name.replace("'", "").strip()
+    for cut in eval(cuts):
+        if name in ak.fields(events):
+            events[name] = events[name] & (events[cut])
+        else:
+            events[name] = events[cut]
+    return events
+
+#create mask for pulses in each layer
+def layerCut(events):
+    events['layer0'] = events.layer == 0
+    events['layer1'] = events.layer == 1
+    events['layer2'] = events.layer == 2
+    events['layer3'] = events.layer == 3
+    return events
+
+#event level mask selecting events with hits in 4 layers
+def fourLayerCut(events):
+    events['fourLayers'] = ak.any(events.layer0, axis=1) & ak.any(events.layer1, axis=1) & ak.any(events.layer2, axis=1) & ak.any(events.layer3, axis=1)
+    return events
+
+#create mask for pulses passing height cut
+def heightCut(events, heightCut=1200):
+    events['heightCut'] = events.height >= int(heightCut)
+    return events
+
+#selection events that have hits in a straight path
+#option allowedMove will select events that only move one bar horizontally/vertically
+def straightLineCut(events, allowedMove=False):
+    
+    #allowed combinations of moving
+    combos = []
+    straight_cuts = []
+
+    #bool to decide if 1 bar movement should be found
+    allowedMove = False
+
+    debugEvt = 1191
+
+    for i, x in enumerate(range(4)):
+        for j, y in enumerate(range(4)):
+
+            rowCut = events.row == y
+            colCut = events.column == x
+
+            r_tmp0 = (rowCut[events.layer0] & colCut[events.layer0])
+            r_tmp1 = (rowCut[events.layer1] & colCut[events.layer1])
+            r_tmp2 = (rowCut[events.layer2] & colCut[events.layer2])
+            r_tmp3 = (rowCut[events.layer3] & colCut[events.layer3])
+
+
+            row_pass = ak.any(r_tmp0, axis=1) & ak.any(r_tmp1, axis=1) & ak.any(r_tmp2, axis=1) & ak.any(r_tmp3, axis=1)
+
+            if allowedMove:
+                rowCut_p1 = events.row == y+1
+                rowCut_m1 = events.row == y-1
+                colCut_p1 = events.column == x+1
+                colCut_m1 = events.column == x-1
+                if(y > 0): 
+                    m1_c0_r1 = (rowCut_m1[events.layer1]) & (colCut[events.layer1])
+                    m2_c0_r1 = (rowCut_m1[events.layer2]) & (colCut[events.layer2])
+                    m3_c0_r1 = (rowCut_m1[events.layer3]) & (colCut[events.layer3])
+                if(x > 0): 
+                    m1_c1_r0 = (rowCut[events.layer1]) & (colCut_m1[events.layer1])
+                    m2_c1_r0 = (rowCut[events.layer2]) & (colCut_m1[events.layer2])
+                    m3_c1_r0 = (rowCut[events.layer3]) & (colCut_m1[events.layer3])
+
+                if(y < 4): 
+                    p1_c0_r1 = (rowCut_p1[events.layer1]) & (colCut[events.layer1])
+                    p2_c0_r1 = (rowCut_p1[events.layer2]) & (colCut[events.layer2])
+                    p3_c0_r1 = (rowCut_p1[events.layer3]) & (colCut[events.layer3])
+                if(x < 4): 
+                    p1_c1_r0 = (rowCut[events.layer1]) & (colCut_p1[events.layer1])
+                    p2_c1_r0 = (rowCut[events.layer2]) & (colCut_p1[events.layer2])
+                    p3_c1_r0 = (rowCut[events.layer3]) & (colCut_p1[events.layer3])
+
+                if(x > 0):
+                    combos.append(ak.any(r_tmp0, axis=1) & ak.any(r_tmp1, axis=1) & ak.any(r_tmp2, axis=1) & ak.any(m3_c1_r0, axis=1)) #layer3 col decrease
+                    combos.append( ak.any(r_tmp0, axis=1) & ak.any(r_tmp1, axis=1) & ak.any(m2_c1_r0, axis=1) & ak.any(m3_c1_r0, axis=1)) #layer2 col decrease
+                    combos.append( ak.any(r_tmp0, axis=1) & ak.any(m1_c1_r0, axis=1) & ak.any(m2_c1_r0, axis=1) & ak.any(m3_c1_r0, axis=1)) #layer1 col decrease
+                if(y > 0):
+                    combos.append(ak.any(r_tmp0, axis=1) & ak.any(r_tmp1, axis=1) & ak.any(r_tmp2, axis=1) & ak.any(m3_c0_r1, axis=1)) #layer3 row decrease
+                    combos.append( ak.any(r_tmp0, axis=1) & ak.any(r_tmp1, axis=1) & ak.any(m2_c0_r1, axis=1) & ak.any(m3_c0_r1, axis=1)) #layer2 row decrease
+                    combos.append( ak.any(r_tmp0, axis=1) & ak.any(m1_c0_r1, axis=1) & ak.any(m2_c0_r1, axis=1) & ak.any(m3_c0_r1, axis=1)) #layer1 row decrease
+                if(x < 4):
+                    combos.append(ak.any(r_tmp0, axis=1) & ak.any(r_tmp1, axis=1) & ak.any(r_tmp2, axis=1) & ak.any(p3_c1_r0, axis=1)) #layer3 col increase
+                    combos.append( ak.any(r_tmp0, axis=1) & ak.any(r_tmp1, axis=1) & ak.any(p2_c1_r0, axis=1) & ak.any(p3_c1_r0, axis=1)) #layer2 col increase
+                    combos.append( ak.any(r_tmp0, axis=1) & ak.any(p1_c1_r0, axis=1) & ak.any(p2_c1_r0, axis=1) & ak.any(p3_c1_r0, axis=1)) #layer1 col increase
+                if(y < 4):
+                    combos.append(ak.any(r_tmp0, axis=1) & ak.any(r_tmp1, axis=1) & ak.any(r_tmp2, axis=1) & ak.any(p3_c0_r1, axis=1)) #layer3 row increase
+                    combos.append( ak.any(r_tmp0, axis=1) & ak.any(r_tmp1, axis=1) & ak.any(p2_c0_r1, axis=1) & ak.any(p3_c0_r1, axis=1)) #layer2 row increase
+                    combos.append( ak.any(r_tmp0, axis=1) & ak.any(p1_c0_r1, axis=1) & ak.any(p2_c0_r1, axis=1) & ak.any(p3_c0_r1, axis=1)) #layer1 row increase
+
+            straight_cuts.append(row_pass)
+    
+    for ipath, path in enumerate(straight_cuts):
+        if ipath == 0: straight_path = path
+        else: straight_path = straight_path | path
+
+    events['straightPath'] = straight_path
+
+    for x in range(4):
+        for y in range(4):
+            if(x == 0 and y == 0): straight_pulse = (straight_cuts[4*x+y]) & (events.column == x) & (events.row == y)
+            else: straight_pulse = (straight_pulse) | ((straight_cuts[4*x+y]) & (events.column == x) & (events.row == y))
+
+    events['straightPulses'] = straight_pulse
+
+    #get events passing 1 bar movement
+    if allowedMove:
+        for ipath, path in enumerate(combos):
+            if ipath == 0: passing = path
+            else: passing = passing | path
+
+        events['moveOnePath'] = passing
+
+    return events
+
+#select events that have 3 area saturating pulses in a line
+def threeAreaSaturatedInLine(events, areaCut=50000):
+    #make sure 3 layers have saturating hits
+    saturating_cut = 500000
+    sat_0 = events.area[(events.eventCuts) & (events.layer0) & (events.area >= saturating_cut) & (events.straightPulses)]
+    sat_1 = events.area[(events.eventCuts) & (events.layer1) & (events.area >= saturating_cut) & (events.straightPulses)]
+    sat_2 = events.area[(events.eventCuts) & (events.layer2) & (events.area >= saturating_cut) & (events.straightPulses)]
+    sat_3 = events.area[(events.eventCuts) & (events.layer3) & (events.area >= saturating_cut) & (events.straightPulses)]
+    
+    events['three_sat'] = ak.any(sat_0, axis=1) & ak.any(sat_1, axis=1) & ak.any(sat_2, axis=1) | (ak.any(sat_0, axis=1) & ak.any(sat_1, axis=1) & ak.any(sat_3, axis=1)) | (ak.any(sat_0, axis=1) & ak.any(sat_2, axis=1) & ak.any(sat_3, axis=1)) | (ak.any(sat_1, axis=1) & ak.any(sat_2, axis=1) & ak.any(sat_3, axis=1))
+    events['four_sat'] = ak.any(sat_0, axis=1) & ak.any(sat_1, axis=1) & ak.any(sat_2, axis=1) & (ak.any(sat_3, axis=1))
+    return events
+    
+#select events that have 3 height saturating pulses in a line
+def threeAreaSaturatedInLine(events, areaCut=50000):
+    #make sure 3 layers have saturating hits
+    saturating_cut = 500000
+    sat_0 = events.area[(events.eventCuts) & (events.layer0) & (events.area >= saturating_cut) & (events.straightPulses)]
+    sat_1 = events.area[(events.eventCuts) & (events.layer1) & (events.area >= saturating_cut) & (events.straightPulses)]
+    sat_2 = events.area[(events.eventCuts) & (events.layer2) & (events.area >= saturating_cut) & (events.straightPulses)]
+    sat_3 = events.area[(events.eventCuts) & (events.layer3) & (events.area >= saturating_cut) & (events.straightPulses)]
+    
+    events['three_sat'] = ak.any(sat_0, axis=1) & ak.any(sat_1, axis=1) & ak.any(sat_2, axis=1) | (ak.any(sat_0, axis=1) & ak.any(sat_1, axis=1) & ak.any(sat_3, axis=1)) | (ak.any(sat_0, axis=1) & ak.any(sat_2, axis=1) & ak.any(sat_3, axis=1)) | (ak.any(sat_1, axis=1) & ak.any(sat_2, axis=1) & ak.any(sat_3, axis=1))
+    events['four_sat'] = ak.any(sat_0, axis=1) & ak.any(sat_1, axis=1) & ak.any(sat_2, axis=1) & (ak.any(sat_3, axis=1))
+    return events
+
+def matchedTDCTimes(events):
+    board0 = events.v_groupTDC_g0[:, 0]
+    board1 = events.v_groupTDC_g0[:, 1]
+    board2 = events.v_groupTDC_g0[:, 2]
+    board3 = events.v_groupTDC_g0[:, 3]
+    board4 = events.v_groupTDC_g0[:, 4]
+
+    events['tdcMatch'] = (board0 == board1) & (board0 == board2) & (board0 == board3) & (board0 == board4)
+    return events

--- a/Run3Detector/analysis/utilities/milliqanProcessor.py
+++ b/Run3Detector/analysis/utilities/milliqanProcessor.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python3
+
+import ROOT as r
+import uproot
+import matplotlib.pyplot as plt
+import awkward as ak
+import numpy as np
+import array as arr
+from milliqanCuts import *
+
+class milliqanProcessor():
+
+    def __init__(self, filelist, branches):
+        self.filelist = filelist
+        self.branches = branches
+
+    def setBranches(self, branches):
+        self.branchesToMake = branches
+
+    def setCuts(self, cuts):
+        self.cuts = cuts
+
+    def makeBranches(self, events):
+        for branch in self.branchesToMake:
+            if '(' in branch:
+                branch = branch.split('(')
+                fcn = eval(branch[0])
+                args = branch[1].split(')')[0]
+                args = args.split(';')
+                events = fcn(events, *args)
+            else:
+                fcn = eval(branch)
+                events = fcn(events)
+        return events
+
+    def makeCuts(self, events):
+        return events
+
+    def runCustomFunction(self, events):
+        try:
+            return self.customFunction(events)
+        except:
+            return
+
+    def setCustomFunction(self, fcn):
+        self.customFunction = fcn
+
+    def makeHistograms(self, root=True, matplot=False):
+        if matplot:
+            self.ax2.scatter(ak.flatten(self.custom_out[3]).to_numpy(), ak.flatten(self.custom_out[0]).to_numpy(), s=5)
+        if root:
+            t0 = ak.flatten(self.custom_out[0]).to_list()
+            t0 = arr.array('d', t0)
+            if len(t0) > 0:
+                t3 = arr.array('d', ak.flatten(self.custom_out[3]).to_list())
+                self.h_time0.FillN(len(t0), t0, np.ones(len(t0)))
+                self.h_timeDiff.FillN(len(t0), t0, t3, np.ones(len(t0)))
+
+
+    def run(self):
+
+        total_events = 0
+        passing_events = 0
+        
+        self.fig2, self.ax2 = plt.subplots()
+        self.ax2.set(xlim=(1200, 1400), ylim=(1200, 1400))
+
+        self.h_timeDiff = r.TH2F("h_timeDiff", "Time Difference Layer0 and Layer3", 200, 1200, 1400, 200, 1200, 1400)
+        self.h_time0 = r.TH1F("h_time0", "Time in Layer 0", 200, 1200, 1400)
+        
+        for events in uproot.iterate(
+
+            #files
+            self.filelist,
+
+            #branches
+            self.branches,
+
+            step_size=1000,
+
+            num_workers=8,
+
+            ):
+
+            events = self.makeBranches(events)
+
+            events = self.makeCuts(events)
+
+            self.custom_out = self.runCustomFunction(events)
+
+            #self.makeHistograms()
+
+            total_events += len(events)
+            passing_events += len(ak.where(events.fourLayers)[0])
+ 
+        print("Number of events", total_events)
+        print("Number of passing events", passing_events)


### PR DESCRIPTION
DQM:
Add script checkMatching to make several checks of the trigger matching and offline files. Python notebook version is useful for working in a pandas dataframe and highlighting issues. All info is saved to a json that should be used to select good runs in the future.

Checks:

- DAQ, trigger, match, and offline file exists for each run/file
- number of events match between files
- number of unmatched triggers
- number of unmatched digitizer boards
- file creation time for generating new versions of offline files

MilliQan Processor:
utilities folder now contains the first (rough) draft of a milliqan processor (milliqanProcessor.py) for analyzing data. The processor uses uproot to iterate over all files passed to it via a file list. It can then make selections using cuts from (milliqanCuts.py) where the cuts are passed as an array of cut strings to the processor. See exampleProcessor.ipynb as a working example. The processor can also make histograms but a more developed "milliqanPlotter" is needed.
