### PR TITLE
Bug Fix in Pickup Cut

### DIFF
--- a/Run3Detector/analysis/utilities/milliqanCuts.py
+++ b/Run3Detector/analysis/utilities/milliqanCuts.py
@@ -46,11 +46,11 @@ class milliqanCuts():
     def pickupCut(self, cutName=None, cut=False, tight=False, branches=None):
         if cut and tight:
             for branch in branches:
-                self.events[branch] = self.events[branch][self.events.pickupFlag]
+                self.events[branch] = self.events[branch][!self.events.pickupFlagTight]
         elif cut and not tight:
             for branch in branches:
                 if branch == 'boardsMatched': continue
-                self.events[branch] = self.events[branch][self.events.pickupFlag]
+                self.events[branch] = self.events[branch][!self.events.pickupFlag]
 
     def boardsMatched(self, cutName=None, cut=False, branches=None):
         self.events['boardsMatched'], junk = ak.broadcast_arrays(self.events.boardsMatched, self.events.pickupFlag)


### PR DESCRIPTION
The pickup cut in milliQanCuts.py was selecting pickup rather than vetoing based off the definition below

https://github.com/milliQan-sw/milliqanOffline/blob/master/Run3Detector/src/OfflineFactory.cc#L1735